### PR TITLE
Change gcr project to official google_containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ all: push
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
 TAG = 0.1
 
-# TODO(random-liu): Change the project to google_containers.
-PROJ = google.com/noogler-kubernetes
+PROJ = google_containers
 
 node-problem-detector: node_problem_detector.go
 	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o node-problem-detector

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -14,7 +14,7 @@ spec:
         command:
         - /node-problem-detector
         - --kernel-monitor=/config/kernel-monitor.json
-        image: gcr.io/google.com/noogler-kubernetes/node-problem-detector:0.1
+        image: gcr.io/google_containers/node-problem-detector:0.1
         imagePullPolicy: Always
         env:
         # Config the host ip and port of apiserver.


### PR DESCRIPTION
This update the gcr project to the official one.
I've already upload an image `node-problem-detector:0.1` to google_containers, will send a PR to kubernetes to add it as an add-on pod soon.

@dchen1107 