### PR TITLE
Make condition and source configurable

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -1,6 +1,14 @@
 {
 	"logPath": "/log/kern.log",
 	"bufferSize": 10,
+	"source": "kernel-monitor",
+	"conditions": [
+		{
+			"type": "KernelDeadlock",
+			"reason": "KernelHasNoDeadlock",
+			"message": "kernel has no deadlock"
+		}
+	],
 	"rules": [
 		{
 			"type": "temporary",
@@ -14,17 +22,20 @@
 		},
 		{
 			"type": "permanent",
+			"condition": "KernelDeadlock",
 			"reason": "AUFSUmountHung",
 			"pattern": "task umount\\.aufs:\\w+ blocked for more than \\w+ seconds\\."
 		},
 		{
 			"type": "permanent",
+			"condition": "KernelDeadlock",
 			"reason": "DockerHung",
 			"pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
 		},
 		{
 			"type": "permanent",
-			"reason": "KernelBug",
+			"condition": "KernelDeadlock",
+			"reason": "UnregisterNetDeviceIssue",
 			"pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
 		}
 	]

--- a/pkg/kernelmonitor/types/types.go
+++ b/pkg/kernelmonitor/types/types.go
@@ -37,6 +37,10 @@ const (
 type Rule struct {
 	// Type is the type of matched kernel problem.
 	Type Type `json:"type"`
+	// Condition is the type of the condition the kernel problem triggered. Notice that
+	// the Condition field should be set only when the problem is permanent, or else the
+	// field will be ignored.
+	Condition string `json:"condition"`
 	// Reason is the short reason of the kernel problem.
 	Reason string `json:"reason"`
 	// Pattern is the regular expression to match the kernel problem in kernel log.

--- a/pkg/problemclient/problem_client.go
+++ b/pkg/problemclient/problem_client.go
@@ -123,6 +123,7 @@ func getEventRecorder(c *client.Client, nodeName, source string) record.EventRec
 }
 
 func getNodeRef(nodeName string) *api.ObjectReference {
+	// TODO(random-liu): Get node to initalize the node reference
 	return &api.ObjectReference{
 		Kind:      "Node",
 		Name:      nodeName,

--- a/pkg/problemdetector/problem_detector.go
+++ b/pkg/problemdetector/problem_detector.go
@@ -65,10 +65,12 @@ func (p *problemDetector) Run() error {
 				glog.Errorf("Monitor stopped unexpectedly")
 				break
 			}
-			if status.Event != nil {
-				p.client.Eventf(util.ConvertToAPIEventType(status.Event.Severity), status.Source, status.Event.Reason, status.Event.Message)
+			for _, event := range status.Events {
+				p.client.Eventf(util.ConvertToAPIEventType(event.Severity), status.Source, event.Reason, event.Message)
 			}
-			p.conditionManager.UpdateCondition(status.Condition)
+			for _, condition := range status.Conditions {
+				p.conditionManager.UpdateCondition(condition)
+			}
 		}
 	}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -69,10 +69,10 @@ type Event struct {
 type Status struct {
 	// Source is the name of the problem daemon.
 	Source string `json:"source"`
-	// Event is the temporary node problem event. If the status is only a condition update,
-	// this field could be nil.
-	Event *Event `json:"event"`
-	// Condition is the permanent node condition. The problem daemon should always report the
-	// newest node condition in this field.
-	Condition Condition `json:"condition"`
+	// Events are temporary node problem events. If the status is only a condition update,
+	// this field could be nil. Notice that the events should be sorted from oldest to newest.
+	Events []Event `json:"events"`
+	// Conditions are the permanent node conditions. The problem daemon should always report the
+	// newest node conditions in this field.
+	Conditions []Condition `json:"conditions"`
 }


### PR DESCRIPTION
Based on #11, only the last commit is new.

This PR:
1. makes node condition and source configurable.
2. adds multiple events and conditions support in problem interface.

We make this change mainly for extensibility, testability and performance.
* Testability: The PR makes it possible to write e2e test which generates test only conditions and events without affecting real node problem detector.
* Extensibility: The PR makes it possible to extend condition types (we only support `KernelDeadlock` before) by just updating configuration.
* Performance: The PR makes it possible to batch reporting events and condition updates.

@dchen1107 
/cc @kubernetes/sig-node 