### PR TITLE
Hack for unsupported OS distros.

### DIFF
--- a/pkg/problemdetector/problem_detector.go
+++ b/pkg/problemdetector/problem_detector.go
@@ -60,11 +60,7 @@ func (p *problemDetector) Run() error {
 	glog.Info("Problem detector started")
 	for {
 		select {
-		case status, ok := <-ch:
-			if !ok {
-				glog.Errorf("Monitor stopped unexpectedly")
-				break
-			}
+		case status := <-ch:
 			for _, event := range status.Events {
 				p.client.Eventf(util.ConvertToAPIEventType(event.Severity), status.Source, event.Reason, event.Message)
 			}


### PR DESCRIPTION
This is a hack for unsupported OS distros.
KernelMonitor doesn't support some OS distros for now e.g. GCI. Ideally, we should only run KernelMonitor on nodes on supported OS distro. However, NodeProblemDetector is running as DaemonSet, it has to be deployed on each node:
  * There is no node affinity support for DaemonSet now https://github.com/kubernetes/kubernetes/issues/22205
  * There is no node label for OS Distro, so we can't use node selector, either

If some nodes have unsupported OS distro e.g. the OS distro of master node in gke/gce is GCI, KernelMonitor will throw out error, and NodeProblemDetector will be restarted again and again because it's a DaemonSet.

To avoid this, we decide to add this temporarily hack. When KernelMonitor can't find the kernel log file, it will print a log and then return nil channel and no error. Since nil channel will always be blocked, the NodeProblemDetector will block forever.

I've tried to schedule the NodeProblemDetector on GCI image, the cpu usage is `0.01% core` and memory usage is `< 5MB`.

TODOs:
1. Add journald support to support GCI. Consider reusing [the code in cadvisor](https://github.com/google/cadvisor/blob/master/utils/oomparser/oomparser.go#L168), and maybe replace hpcloud/tail with the simpler implementation in cadvisor https://github.com/kubernetes/node-problem-detector/issues/3
2. Schedule KernelMonitor only on nodes with supported OS distros. (with node label+selector or affinity)

@dchen1107 
/cc @kubernetes/sig-node 