### PR TITLE
Add entrypoint and copy kernel monitor config into docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,5 @@
 FROM alpine:3.1
 MAINTAINER Random Liu <lantaol@google.com>
 ADD node-problem-detector /node-problem-detector
+ADD config /config
+ENTRYPOINT ["/node-problem-detector", "--kernel-monitor=/config/kernel-monitor.json"]


### PR DESCRIPTION
Add entrypoint and config into docker image, so as to simplify node problem detector deployment in Kubernetes.

Addon manager doesn't support ConfigMap now. We could change addon manager to support ConfigMap and also add ConfigMap in addon manifests, but that is not necessary and we should not make that big change before cutting release.
Even though we added entrypoint and config into the docker image, we can always overwrite them in the yaml file in the future.