### PR TITLE
Containerize the nethealth bandwidth measurement utility

### DIFF
--- a/pkg/util/nethealth/Dockerfile
+++ b/pkg/util/nethealth/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2016 The Kubernetes Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+MAINTAINER Girish Kalele <gkalele@google.com>
+COPY nethealth /usr/bin/
+ENTRYPOINT ["/usr/bin/nethealth"]

--- a/pkg/util/nethealth/Makefile
+++ b/pkg/util/nethealth/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Makefile for the Docker image gcr.io/google_containers/kube-nethealth-<ARCH>
+# MAINTAINER: Girish kalele <abshah@google.com>
+# If you update this image please bump the tag value before pushing.
+#
+# Usage:
+#   [TAG=1.0] [REGISTRY=gcr.io/google_containers] make push
+
+# Default registry, arch and tag. This can be overwritten by arguments to make
+TAG?=1.0
+REGISTRY?=gcr.io/google_containers
+ARCH?=amd64
+
+all: build
+
+nethealth: nethealth.go
+	CGO_ENABLED=0 go build -ldflags '-s' -v -o nethealth nethealth.go
+
+build: nethealth
+	docker build -t $(REGISTRY)/kube-nethealth-$(ARCH):$(TAG) .
+
+push: build
+ifeq ($(REGISTRY),gcr.io/google_containers)
+	gcloud docker push $(REGISTRY)/kube-nethealth-$(ARCH):$(TAG)
+else
+	docker push $(REGISTRY)/kube-nethealth-$(ARCH):$(TAG)
+endif
+
+.PHONY: push


### PR DESCRIPTION
```
$ docker run -it --rm gcr.io/google_containers/kube-nethealth-amd64:1.0
2016/06/08 01:04:47 HTTP HEAD reports content length: 67108864 - running GET
2016/06/08 01:04:53 DOWNLOAD: 67108864 bytes 5956 ms Bandwidth ~ 11003 KiB/sec
2016/06/08 01:04:53 Hash Matches expected value
```