### PR TITLE
Kernel Monitor: Add look back support and kernel panic handling

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -1,5 +1,7 @@
 {
 	"logPath": "/log/kern.log",
+	"lookback": "10m",
+	"startPattern": "Initializing cgroup subsys cpuset",
 	"bufferSize": 10,
 	"source": "kernel-monitor",
 	"conditions": [
@@ -19,6 +21,16 @@
 			"type": "temporary",
 			"reason": "TaskHung",
 			"pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
+		},
+		{
+			"type": "temporary",
+			"reason": "KernelPanic",
+			"pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
+		},
+		{
+			"type": "temporary",
+			"reason": "KernelPanic",
+			"pattern": "divide error: 0000 \\[#\\d+\\] SMP"
 		},
 		{
 			"type": "permanent",

--- a/demo/demo
+++ b/demo/demo
@@ -31,8 +31,8 @@ rebootAll() {
 
 reboot() {
   LATEST=`gcloud compute ssh -n root@$1 --zone=$ZONE "tail -1 $KERNLOG"`
-  PREFIX=`echo $LATEST | cut -d "[" -f 1 -`"[0.000000]"
-  runCmd "gcloud compute ssh -n root@$1 --zone=$ZONE \"echo '$PREFIX reboot' >> $KERNLOG\""
+  PREFIX=`echo $LATEST | cut -d "]" -f 1 -`"]"
+  runCmd "gcloud compute ssh -n root@$1 --zone=$ZONE \"echo '$PREFIX Initializing cgroup subsys cpuset' >> $KERNLOG\""
 }
 
 case $1 in

--- a/demo/divide_zero
+++ b/demo/divide_zero
@@ -1,0 +1,36 @@
+divide error: 0000 [#1] SMP 
+Modules linked in: dm_thin_pool dm_persistent_data dm_bio_prison dm_bufio libcrc32c xt_statistic xt_nat xt_mark ipt_REJECT xt_tcpudp xt_comment loop veth binfmt_misc sch_htb ipt_MASQUERADE iptable_nat nf_conntrack_ipv4 nf_defrag_ipv4 nf_nat_ipv4 xt_addrtype iptable_filter ip_tables x_tables nf_nat nf_conntrack bridge stp llc aufs(C) nfsd auth_rpcgss oid_registry nfs_acl nfs lockd fscache sunrpc crc32_pclmul ppdev aesni_intel aes_x86_64 lrw gf128mul glue_helper ablk_helper cryptd evdev psmouse serio_raw parport_pc ttm parport drm_kms_helper drm i2c_piix4 i2c_core processor button thermal_sys autofs4 ext4 crc16 mbcache jbd2 btrfs xor raid6_pq dm_mod ata_generic crct10dif_pclmul crct10dif_common xen_netfront xen_blkfront crc32c_intel ata_piix libata scsi_mod floppy
+CPU: 1 PID: 1853 Comm: docker Tainted: G         C    3.16.0-4-amd64 #1 Debian 3.16.7-ckt20-1+deb8u4
+Hardware name: Xen HVM domU, BIOS 4.2.amazon 05/12/2016
+task: ffff8801e3657470 ti: ffff8801e47a8000 task.ti: ffff8801e47a8000
+RIP: 0010:[<ffffffffa0577200>]  [<ffffffffa0577200>] pool_io_hints+0xf0/0x1a0 [dm_thin_pool]
+RSP: 0018:ffff8801e47abbc8  EFLAGS: 00010246
+RAX: 0000000000010000 RBX: ffff8801e4736840 RCX: ffff8801c2662000
+RDX: 0000000000000000 RSI: 0000000000000000 RDI: ffff8801e48c4080
+RBP: ffff8801e47abc10 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000246 R12: ffffffffa057f5c8
+R13: 0000000000000001 R14: ffff8801e47abc90 R15: 0000000000000131
+FS:  00007ff465daf700(0000) GS:ffff8801efc20000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 000000c207f1c3fb CR3: 00000001e2a5a000 CR4: 00000000001406e0
+Stack:
+ ffffffff810a7c71 0000000043e06d70 ffffc9000115f040 0000000000000000
+ 0000000043e06d70 ffffc9000115f040 0000000000000000 ffff8800e9da3800
+ ffffffffa00ba615 000fffffffffffff 00000000ffffffff 00000000000000ff
+Call Trace:
+ [<ffffffff810a7c71>] ? complete+0x31/0x40
+ [<ffffffffa00ba615>] ? dm_calculate_queue_limits+0x95/0x130 [dm_mod]
+ [<ffffffffa00b7ec3>] ? dm_swap_table+0x73/0x320 [dm_mod]
+ [<ffffffffa00b0101>] ? crc_t10dif_generic+0x101/0x1000 [crct10dif_common]
+ [<ffffffffa00bd0d0>] ? table_load+0x330/0x330 [dm_mod]
+ [<ffffffffa00bd165>] ? dev_suspend+0x95/0x220 [dm_mod]
+ [<ffffffffa00bda55>] ? ctl_ioctl+0x205/0x430 [dm_mod]
+ [<ffffffffa00bdc8f>] ? dm_ctl_ioctl+0xf/0x20 [dm_mod]
+ [<ffffffff811ba99f>] ? do_vfs_ioctl+0x2cf/0x4b0
+ [<ffffffff810d485e>] ? SyS_futex+0x6e/0x150
+ [<ffffffff811bac01>] ? SyS_ioctl+0x81/0xa0
+ [<ffffffff81513ecd>] ? system_call_fast_compare_end+0x10/0x15
+Code: 0f 84 a5 00 00 00 3b 96 10 06 00 00 49 c7 c4 c8 f5 57 a0 77 26 8b b6 18 06 00 00 89 d0 c1 e0 09 48 39 f0 0f 82 92 00 00 00 31 d2 <48> f7 f6 85 d2 74 2d 49 c7 c4 70 f5 57 a0 66 90 48 89 e6 e8 28 
+RIP  [<ffffffffa0577200>] pool_io_hints+0xf0/0x1a0 [dm_thin_pool]
+ RSP <ffff8801e47abbc8>
+---[ end trace fcce781faebae9ce ]---

--- a/demo/null_pointer
+++ b/demo/null_pointer
@@ -1,0 +1,36 @@
+BUG: unable to handle kernel NULL pointer dereference at 0000000000000078
+IP: [<ffffffff810a2c38>] pick_next_task_fair+0x6b8/0x820
+PGD 0 
+Oops: 0000 [#1] SMP 
+Modules linked in: binfmt_misc ipt_REJECT xt_nat xt_tcpudp xt_multiport veth xt_conntrack ipt_MASQUERADE iptable_nat nf_conntrack_ipv4 nf_defrag_ipv4 nf_nat_ipv4 xt_addrtype iptable_filter ip_tables x_tables nf_nat nf_conntrack bridge stp llc aufs(C) cpufreq_conservative cpufreq_powersave cpufreq_stats cpufreq_userspace xfs libcrc32c x86_pkg_temp_thermal intel_powerclamp intel_rapl coretemp kvm_intel kvm crc32_pclmul iTCO_wdt iTCO_vendor_support aesni_intel aes_x86_64 lrw gf128mul ttm glue_helper evdev ablk_helper cryptd drm_kms_helper drm serio_raw shpchp i2c_i801 lpc_ich mfd_core wmi ipmi_msghandler processor tpm_infineon thermal_sys tpm_tis tpm acpi_pad button autofs4 ext4 crc16 mbcache jbd2 btrfs xor raid6_pq dm_mod raid1 md_mod sg sd_mod crc_t10dif crct10dif_generic crct10dif_pclmul crct10dif_common crc32c_intel ehci_pci ahci igb libahci xhci_hcd ehci_hcd i2c_algo_bit i2c_core libata dca ptp usbcore scsi_mod pps_core usb_common
+CPU: 11 PID: 63 Comm: ksoftirqd/11 Tainted: G         C    3.16.0-4-amd64 #1 Debian 3.16.7-ckt20-1+deb8u3
+Hardware name: ASUSTeK COMPUTER INC. Z10PA-U8 Series/Z10PA-U8 Series, BIOS 0601 06/26/2015
+task: ffff881fe1d0cb60 ti: ffff881fe1d18000 task.ti: ffff881fe1d18000
+RIP: 0010:[<ffffffff810a2c38>]  [<ffffffff810a2c38>] pick_next_task_fair+0x6b8/0x820
+RSP: 0018:ffff881fe1d1bde0  EFLAGS: 00010046
+RAX: 0000000000000000 RBX: ffff881fa84a3580 RCX: 0000000000000000
+RDX: 0000000000000001 RSI: ffff881fb5837628 RDI: ffff881d1fab2308
+RBP: ffff881fb5837600 R08: 0000000000000000 R09: 000000000000b9dc
+R10: 0000000000000004 R11: 0000000000000005 R12: 0000000000000000
+R13: 0000000000000000 R14: 0000000000000000 R15: ffff88207fd72f00
+FS:  0000000000000000(0000) GS:ffff88207fd60000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 0000000000000078 CR3: 0000000001813000 CR4: 00000000001407e0
+Stack:
+ ffff881d1fab2290 000000018109ef94 ffff881fe1d0cb60 0000000000012f00
+ ffff88207fd72f78 ffffffff8101b975 ffff881fe1d0cfb8 ffff881fe1d0cb60
+ ffff88207fd72f00 000000000000000b 0000000000000000 0000000000000000
+Call Trace:
+ [<ffffffff8101b975>] ? sched_clock+0x5/0x10
+ [<ffffffff8150fed6>] ? __schedule+0x106/0x700
+ [<ffffffff8108ea86>] ? smpboot_thread_fn+0xc6/0x190
+ [<ffffffff8108e9c0>] ? SyS_setgroups+0x170/0x170
+ [<ffffffff8108805d>] ? kthread+0xbd/0xe0
+ [<ffffffff81087fa0>] ? kthread_create_on_node+0x180/0x180
+ [<ffffffff81513c58>] ? ret_from_fork+0x58/0x90
+ [<ffffffff81087fa0>] ? kthread_create_on_node+0x180/0x180
+Code: 49 8b 7c 24 78 48 39 fd 74 2f 44 8b 73 68 45 8b 6c 24 68 45 39 ee 0f 8e c7 00 00 00 48 89 ef 48 89 de e8 fc 91 ff ff 48 8b 5b 70 <49> 8b 7c 24 78 48 8b 6b 78 48 39 fd 75 d1 48 85 ed 74 cc 4c 89 
+RIP  [<ffffffff810a2c38>] pick_next_task_fair+0x6b8/0x820
+ RSP <ffff881fe1d1bde0>
+CR2: 0000000000000078
+---[ end trace 61f6991dc9ee5be0 ]---

--- a/node_problem_detector.go
+++ b/node_problem_detector.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	kernelMonitorConfigPath = flag.String("kernel-monitor", "/config/kernel_monitor", "The path to the kernel monitor config file")
+	kernelMonitorConfigPath = flag.String("kernel-monitor", "/config/kernel_monitor.json", "The path to the kernel monitor config file")
 )
 
 func main() {

--- a/pkg/kernelmonitor/kernel_monitor_test.go
+++ b/pkg/kernelmonitor/kernel_monitor_test.go
@@ -32,7 +32,6 @@ const (
 )
 
 func TestGenerateStatus(t *testing.T) {
-	uptime := time.Unix(1000, 0)
 	initConditions := []types.Condition{
 		{
 			Type:       testConditionA,
@@ -47,11 +46,11 @@ func TestGenerateStatus(t *testing.T) {
 	}
 	logs := []*kerntypes.KernelLog{
 		{
-			Timestamp: 100000,
+			Timestamp: time.Unix(1000, 1000),
 			Message:   "test message 1",
 		},
 		{
-			Timestamp: 200000,
+			Timestamp: time.Unix(2000, 2000),
 			Message:   "test message 2",
 		},
 	}
@@ -72,7 +71,7 @@ func TestGenerateStatus(t *testing.T) {
 					{
 						Type:       testConditionA,
 						Status:     true,
-						Transition: time.Unix(1000, 100000*1000),
+						Transition: time.Unix(1000, 1000),
 						Reason:     "test reason",
 						Message:    "test message 1\ntest message 2",
 					},
@@ -89,7 +88,7 @@ func TestGenerateStatus(t *testing.T) {
 				Source: testSource,
 				Events: []types.Event{{
 					Severity:  types.Warn,
-					Timestamp: time.Unix(1000, 100000*1000),
+					Timestamp: time.Unix(1000, 1000),
 					Reason:    "test reason",
 					Message:   "test message 1\ntest message 2",
 				}},
@@ -102,7 +101,6 @@ func TestGenerateStatus(t *testing.T) {
 				Source: testSource,
 			},
 			conditions: initConditions,
-			uptime:     uptime,
 		}
 		got := k.generateStatus(logs, test.rule)
 		if !reflect.DeepEqual(&test.expected, got) {

--- a/pkg/kernelmonitor/translator/translator_test.go
+++ b/pkg/kernelmonitor/translator/translator_test.go
@@ -18,33 +18,32 @@ package translator
 
 import (
 	"testing"
+	"time"
 )
 
 func TestDefaultTranslator(t *testing.T) {
 	tr := NewDefaultTranslator()
-
+	year := time.Now().Year()
 	testCases := []struct {
 		input     string
 		err       bool
-		timestamp int64
+		timestamp time.Time
 		message   string
 	}{
 		{
-			input:     "Jan  1 00:00:00 hostname kernel: [9.999999] component: log message",
-			timestamp: 9999999,
+			input:     "May  1 12:23:45 hostname kernel: [0.000000] component: log message",
+			timestamp: time.Date(year, time.May, 1, 12, 23, 45, 0, time.Local),
 			message:   "component: log message",
 		},
 		{
-			input:     "Jan  1 00:00:00 hostname kernel: [9.999999]",
-			timestamp: 9999999,
+			// no log message
+			input:     "May 21 12:23:45 hostname kernel: [9.999999]",
+			timestamp: time.Date(year, time.May, 21, 12, 23, 45, 0, time.Local),
 			message:   "",
 		},
 		{
-			input: "Jan  1 00:00:00 hostname kernel: [9.999999 component: log message",
-			err:   true,
-		},
-		{
-			input: "Jan  1 00:00:00 hostname user: [9.999999] component: log message",
+			// the right square bracket is missing
+			input: "May 21 12:23:45 hostname kernel: [9.999999 component: log message",
 			err:   true,
 		},
 	}
@@ -58,7 +57,7 @@ func TestDefaultTranslator(t *testing.T) {
 			continue
 		}
 		if test.timestamp != log.Timestamp || test.message != log.Message {
-			t.Errorf("case %d: expect timestamp: %d, message: %q; got %+v", c+1, test.timestamp, test.message, log)
+			t.Errorf("case %d: expect %v, %q; got %v, %q", c+1, test.timestamp, test.message, log.Timestamp, log.Message)
 		}
 	}
 }

--- a/pkg/kernelmonitor/types/types.go
+++ b/pkg/kernelmonitor/types/types.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package types
 
+import (
+	"time"
+)
+
 // KernelLog is the log item returned by translator. It's very easy to extend this
 // to support other log monitoring, such as docker log monitoring.
 type KernelLog struct {
-	Timestamp int64 // microseconds since kernel boot
+	Timestamp time.Time
 	Message   string
 }
 


### PR DESCRIPTION
This helps https://github.com/kubernetes/kubernetes/issues/27885.

This PR:
1) Add lookback support in kernel monitor. After started, Kernel monitor will check some old logs to detect old problems which happened before last node reboot.

2) Add `lookback` and `startPattern` in kernel monitor configuration.
  * `lookback` specifies how long time kernel monitor should look back.
  * `startPattern` specifies which log indicates the node is started. kernel monitor will clear all current node conditions once it finds a node start log. This makes sure that old problems won't change the node condition.

3) Add support for kernel panic monitoring, the null pointer and divide 0 kernel panic will be surfaced as event. Usually kernel monitor will report these events during looking back phase.

I've cut a branch v0.1 before this PR, and bump up the image version to v0.2 in this PR.
@dchen1107 
/cc @kubernetes/sig-node 