### PR TITLE
Add --insecure-connection and --hostname-override flag in node problem detector

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -689,6 +689,11 @@
 			"Rev": "e7a13ac2adcfeb6352f895f1e673dddaa3fa496d"
 		},
 		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/node",
+			"Comment": "v1.3.0-alpha.4-688-ge7a13ac",
+			"Rev": "e7a13ac2adcfeb6352f895f1e673dddaa3fa496d"
+		},
+		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/parsers",
 			"Comment": "v1.3.0-alpha.4-688-ge7a13ac",
 			"Rev": "e7a13ac2adcfeb6352f895f1e673dddaa3fa496d"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = v0.1
+TAG = v0.2
 
 PROJ = google_containers
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ spec:
 * If needed, you can use [ConfigMap](http://kubernetes.io/docs/user-guide/configmap/)
 to overwrite the `config/`.
 
+# Flags
+node-problem-detector has several flags:
+* `--kernel-monitor`: The path to the kernel monitor config file.
+ Default: `/config/kernel_monitor.json`
+* `--hostname-override`: If non-empty, node problem detector will use
+  the specified hostname as node identification. Default: ""
+* `--insecure-connection`: If true, node problem detector will skip TLS
+verification while connecting with apiserver. Default: false.
+
 # Links
 * [Design Doc](https://docs.google.com/document/d/1cs1kqLziG-Ww145yN6vvlKguPbQQ0psrSBnEqpy0pzE/edit?usp=sharing)
 * [Slides](https://docs.google.com/presentation/d/1bkJibjwWXy8YnB5fna6p-Ltiy-N5p01zUsA22wCNkXA/edit?usp=sharing)

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -14,7 +14,7 @@ spec:
         command:
         - /node-problem-detector
         - --kernel-monitor=/config/kernel-monitor.json
-        image: gcr.io/google_containers/node-problem-detector:v0.1
+        image: gcr.io/google_containers/node-problem-detector:v0.2
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/node_problem_detector.go
+++ b/node_problem_detector.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	kernelMonitorConfigPath = flag.String("kernel-monitor", "/config/kernel_monitor", "The path to the kernel monitor config file")
+	kernelMonitorConfigPath = flag.String("kernel-monitor", "/config/kernel_monitor.json", "The path to the kernel monitor config file")
 )
 
 func main() {

--- a/vendor/k8s.io/kubernetes/pkg/util/node/node.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/node/node.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+func GetHostname(hostnameOverride string) string {
+	hostname := hostnameOverride
+	if string(hostname) == "" {
+		nodename, err := exec.Command("uname", "-n").Output()
+		if err != nil {
+			glog.Fatalf("Couldn't determine hostname: %v", err)
+		}
+		hostname = string(nodename)
+	}
+	return strings.ToLower(strings.TrimSpace(hostname))
+}
+
+// GetNodeHostIP returns the provided node's IP, based on the priority:
+// 1. NodeInternalIP
+// 2. NodeExternalIP
+// 3. NodeLegacyHostIP
+func GetNodeHostIP(node *api.Node) (net.IP, error) {
+	addresses := node.Status.Addresses
+	addressMap := make(map[api.NodeAddressType][]api.NodeAddress)
+	for i := range addresses {
+		addressMap[addresses[i].Type] = append(addressMap[addresses[i].Type], addresses[i])
+	}
+	if addresses, ok := addressMap[api.NodeInternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	if addresses, ok := addressMap[api.NodeExternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	if addresses, ok := addressMap[api.NodeLegacyHostIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	return nil, fmt.Errorf("host IP unknown; known addresses: %v", addresses)
+}


### PR DESCRIPTION
Fix https://github.com/kubernetes/node-problem-detector/issues/23.
Fix https://github.com/kubernetes/node-problem-detector/issues/21.

This PR added 2 node problem detector flags:
* `--insecure-connection`: This flag will let node problem detector skip TLS verification when talking with apiserver.
* `--hostname-override`: The user could override the host name with this flag. Notice that if you want to override the hostname, you may have to run node problem detector as static pod on each node, and render the flag accordingly with your deployment tool (or manually) to make sure that every node problem detector is properly configured.

@sols1 @ApsOps can any of you help me verify the `--insecure-connection`? I don't have a cluster with no admission control in hand. The image version is v0.2.

@sols1 @ApsOps @wangyumi
/cc @dchen1107 