### PR TITLE
NPD: Get node name from pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: push
 
 # See pod.yaml for the version currently running-- bump this ahead before rebuilding!
-TAG = v0.1
+TAG = v0.2
 
 PROJ = google_containers
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,21 @@ metadata:
 spec:
   template:
     spec:
-      hostNetwork: true
       containers:
       - name: node-problem-detector
-        image: gcr.io/google_containers/node-problem-detector:v0.1
+        image: gcr.io/google_containers/node-problem-detector:v0.2
         imagePullPolicy: Always
         securityContext:
           privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: log
           mountPath: /log

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -8,16 +8,24 @@ spec:
       labels:
         app: node-problem-detector
     spec:
-      hostNetwork: true
       containers:
       - name: node-problem-detector
         command:
         - /node-problem-detector
         - --kernel-monitor=/config/kernel-monitor.json
-        image: gcr.io/google_containers/node-problem-detector:v0.1
+        image: gcr.io/google.com/noogler-kubernetes/node-problem-detector:v0.2
         imagePullPolicy: Always
         securityContext:
           privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: log
           mountPath: /log

--- a/pkg/problemclient/problem_client.go
+++ b/pkg/problemclient/problem_client.go
@@ -57,11 +57,15 @@ func NewClientOrDie() Client {
 	}
 	// TODO(random-liu): Set QPS Limit
 	c.client = client.NewOrDie(cfg)
-	// TODO(random-liu): Get node name from cloud provider
-	c.nodeName, err = os.Hostname()
+	// Get node name from the current pod.
+	pod, err := c.client.Pods(os.Getenv("POD_NAMESPACE")).Get(os.Getenv("POD_NAME"))
 	if err != nil {
 		panic(err)
 	}
+	if pod.Spec.NodeName == "" {
+		panic("empty node name")
+	}
+	c.nodeName = pod.Spec.NodeName
 	c.nodeRef = getNodeRef(c.nodeName)
 	c.recorders = make(map[string]record.EventRecorder)
 	return c


### PR DESCRIPTION
Fixes https://github.com/kubernetes/node-problem-detector/issues/28.
Suggested in https://github.com/kubernetes/kubernetes/pull/27880#issuecomment-238776172.

This PR makes node problem detector to get node name from the pod where it is on, so that the node name should always be consistent with kubelet.