### PR TITLE
NPD: Get node name from the downward api.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-# See pod.yaml for the version currently running-- bump this ahead before rebuilding!
+# See node-problem-detector.yaml for the version currently running-- bump this ahead before rebuilding!
 TAG = v0.2
 
 PROJ = google_containers

--- a/README.md
+++ b/README.md
@@ -73,14 +73,10 @@ spec:
         securityContext:
           privileged: true
         env:
-        - name: POD_NAME
+        - name: NODE_NAME
           valueFrom:
             fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: log
           mountPath: /log

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -18,14 +18,10 @@ spec:
         securityContext:
           privileged: true
         env:
-        - name: POD_NAME
+        - name: NODE_NAME
           valueFrom:
             fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: log
           mountPath: /log


### PR DESCRIPTION
Fixes https://github.com/kubernetes/node-problem-detector/issues/25.
Fixes https://github.com/kubernetes/node-problem-detector/issues/23.

https://github.com/kubernetes/kubernetes/pull/27880 has been merged. This PR changes node problem detector to get node name from the downward api.

@dchen1107 