### PR TITLE
NPD: Remove get start point

### DIFF
--- a/pkg/kernelmonitor/kernel_log_watcher_test.go
+++ b/pkg/kernelmonitor/kernel_log_watcher_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pivotal-golang/clock/fakeclock"
 )
 
-func TestGetStartPoint(t *testing.T) {
+func TestWatch(t *testing.T) {
 	// now is a fake time
 	now := time.Date(time.Now().Year(), time.January, 2, 3, 4, 5, 0, time.Local)
 	fakeClock := fakeclock.NewFakeClock(now)


### PR DESCRIPTION
Based on https://github.com/kubernetes/node-problem-detector/pull/31 to enable the presubmit test.

This PR addressed https://github.com/kubernetes/node-problem-detector/issues/3#issuecomment-246431485 to remove the unnecessary `getStartPoint` function.

With this change @AdoHe should be able to use simple tail library directly.