### PR TITLE
Share time with the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,19 @@ spec:
         - name: log
           mountPath: /log
           readOnly: true
+        - name: localtime
+          mountPath: /etc/localtime
+          readOnly: true
       volumes:
       - name: log
         # Config `log` to your system log directory
         hostPath:
           path: /var/log/
+      - name: localtime
+        # Make sure the time in pod is the same with the host
+        hostPath:
+          path: /etc/localtime
+
 ```
 * Edit node-problem-detector.yaml to fit your environment: Set `log` volume to your system log diretory. (Used by KernelMonitor)
 * Create the DaemonSet with `kubectl create -f node-problem-detector.yaml`

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -26,6 +26,11 @@ spec:
         - name: log
           mountPath: /log
           readOnly: true
+        # Make sure node problem detector is in the same timezone
+        # with the host.
+        - name: localtime
+          mountPath: /etc/localtime
+          readOnly: true
         - name: config
           mountPath: /config
           readOnly: true
@@ -34,6 +39,9 @@ spec:
         # Config `log` to your system log directory
         hostPath:
           path: /var/log/
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
       - name: config
         configMap:
           name: node-problem-detector-config


### PR DESCRIPTION
Kernel monitor discard old kernel log based on the timestamp.

However, usually kernel log timestamp doesn't contain year and timezone information, e.g. `Oct 23 16:59:23`. There is no way to apply the right timezone, if the timezone inside the pod is different from the host.

This PR mount the `/etc/localtime` inside the container to make sure the container in the same zone with the host.

Sometimes `/etc/localtime` may be a symlink file. I've tested that both docker and kubernetes mount will follow the symlink and mount the real content.

@dchen1107 
