### PR TITLE
Support getting node name from k8s API

### DIFF
--- a/pkg/problemclient/problem_client.go
+++ b/pkg/problemclient/problem_client.go
@@ -65,6 +65,18 @@ func NewClientOrDie() Client {
 	// 2. For some cloud providers, os.Hostname is different from the real hostname.
 	c.nodeName = os.Getenv("NODE_NAME")
 	if c.nodeName == "" {
+		// k8s v1.3.7 and earlier doesn't provide the node name in the dowwnward API.
+		// However, we can get it from the k8s API.
+		var err error
+		pod, err := c.client.Pods(os.Getenv("POD_NAMESPACE")).Get(os.Getenv("POD_NAME"))
+		if err == nil {
+			node, err := c.client.Nodes().Get(pod.Spec.NodeName)
+			if err == nil {
+				c.nodeName = node.ObjectMeta.Name
+			}
+		}
+	}
+	if c.nodeName == "" {
 		// For backward compatibility. If the env is not set, get the hostname
 		// from os.Hostname(). This may not work for all configurations and
 		// environments.


### PR DESCRIPTION
Hi @Random-Liu, I noticed that you were grabbing the node name from the downward API, which isn't supported in k8s 1.3.7 and below. This patch adds a fallback to using the k8s API at runtime. What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/40)
<!-- Reviewable:end -->
