### PR TITLE
logwatchers: add new kmsg-based kernel log watcher

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/node-problem-detector",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v77",
 	"Packages": [
 		"./..."
 	],
@@ -103,6 +103,11 @@
 			"ImportPath": "github.com/emicklei/go-restful/swagger",
 			"Comment": "v1.2-54-g7c47e25",
 			"Rev": "7c47e2558a0bbbaba9ecab06bc6681e73028a28a"
+		},
+		{
+			"ImportPath": "github.com/euank/go-kmsg-parser/kmsgparser",
+			"Comment": "v2.0.0",
+			"Rev": "5ba4d492e455a77d25dcf0d2c4acc9f2afebef4e"
 		},
 		{
 			"ImportPath": "github.com/ghodss/yaml",

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -27,6 +27,9 @@ spec:
         - name: log
           mountPath: /var/log
           readOnly: true
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
         # Make sure node problem detector is in the same timezone
         # with the host.
         - name: localtime
@@ -40,6 +43,9 @@ spec:
         # Config `log` to your system log directory
         hostPath:
           path: /var/log/
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
       - name: localtime
         hostPath:
           path: /etc/localtime

--- a/pkg/systemlogmonitor/README.md
+++ b/pkg/systemlogmonitor/README.md
@@ -8,10 +8,11 @@ the configuration files. (
 [`config/kernel-monitor.json`](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) as an example).
 The rule list is extensible.
 
-## Limitations
+## Supported sources
 
-* System Log Monitor only supports file based log and journald now, but it is easy
-  to extend it with [new log watcher](#new-log-watcher)
+* System Log Monitor currently supports file-based logs, journald, and kmsg.
+  Additional sources can be added by implementing a [new log
+  watcher](#new-log-watcher).
 
 ## Add New NodeConditions
 
@@ -44,10 +45,10 @@ with new rule definition:
 
 System log monitor supports different log management tools with different log
 watchers:
-* [filelog](https://github.com/kubernetes/node-problem-detector/blob/master/pkg/systemlogmonitor/logwatchers/filelog): Log watcher for
+* [filelog](./logwatchers/filelog): Log watcher for
 arbitrary file based log.
-* [journald](https://github.com/kubernetes/node-problem-detector/blob/master/pkg/systemlogmonitor/logwatchers/journald): Log watcher for
-journald.
+* [journald](.//logwatchers/journald): Log watcher for
+* [kmsg](./logwatchers/kmsg): Log watcher for the kernel ring buffer device, /dev/kmsg.
 Set `plugin` in the configuration file to specify log watcher.
 
 ### Plugin Configuration
@@ -66,6 +67,7 @@ Log watcher specific configurations are configured in `pluginConfig`.
   * timestampFormat: The format of the timestamp. The format string is the time
     `2006-01-02T15:04:05Z07:00` in the expected format. (See
     [golang timestamp format](https://golang.org/pkg/time/#pkg-constants))
+* **kmsg**
 
 ### Change Log Path
 
@@ -78,6 +80,6 @@ field in the configurtion file is the log path. You can always configure
 
 ### New Log Watcher
 
-System log monitor uses [Log
-Watcher](https://github.com/kubernetes/node-problem-detector/blob/master/pkg/systemlogmonitor/logwatchers/types/log_watcher.go) to support different log management tools.
-It is easy to implement a new log watcher.
+System log monitor uses [Log Watcher](./logwatchers/types/log_watcher.go) to
+support different log management tools.  It is easy to implement a new log
+watcher.

--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmsg
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+	"time"
+
+	utilclock "code.cloudfoundry.org/clock"
+	"github.com/euank/go-kmsg-parser/kmsgparser"
+	"github.com/golang/glog"
+
+	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
+	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
+	"k8s.io/node-problem-detector/pkg/systemlogmonitor/util"
+)
+
+type kernelLogWatcher struct {
+	cfg    types.WatcherConfig
+	logCh  chan *logtypes.Log
+	tomb   *util.Tomb
+	reader *bufio.Reader
+
+	kmsgParser kmsgparser.Parser
+	clock      utilclock.Clock
+}
+
+// NewKmsgWatcher creates a watcher which will read messages from /dev/kmsg
+func NewKmsgWatcher(cfg types.WatcherConfig) types.LogWatcher {
+	kmsgparser.NewParser()
+	return &kernelLogWatcher{
+		cfg:  cfg,
+		tomb: util.NewTomb(),
+		// Arbitrary capacity
+		logCh: make(chan *logtypes.Log, 100),
+		clock: utilclock.NewClock(),
+	}
+}
+
+var _ types.WatcherCreateFunc = NewKmsgWatcher
+
+func (k *kernelLogWatcher) Watch() (<-chan *logtypes.Log, error) {
+	if k.kmsgParser == nil {
+		// nil-check to make mocking easier
+		parser, err := kmsgparser.NewParser()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create kmsg parser: %v", err)
+		}
+		k.kmsgParser = parser
+	}
+
+	lookback, err := time.ParseDuration(k.cfg.Lookback)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse lookback duration %q: %v", k.cfg.Lookback, err)
+	}
+
+	go k.watchLoop(lookback)
+	return k.logCh, nil
+}
+
+// Stop closes the kmsgparser
+func (k *kernelLogWatcher) Stop() {
+	k.kmsgParser.Close()
+	k.tomb.Stop()
+}
+
+// watchLoop is the main watch loop of kernel log watcher.
+func (k *kernelLogWatcher) watchLoop(lookback time.Duration) {
+	defer func() {
+		close(k.logCh)
+		k.tomb.Done()
+	}()
+	kmsgs := k.kmsgParser.Parse()
+
+	for {
+		select {
+		case <-k.tomb.Stopping():
+			glog.Infof("Stop watching kernel log")
+			k.kmsgParser.Close()
+			return
+		case msg := <-kmsgs:
+			glog.V(5).Infof("got kernel message: %+v", msg)
+			if msg.Message == "" {
+				continue
+			}
+
+			// Discard too old messages
+			if k.clock.Since(msg.Timestamp) > lookback {
+				glog.V(5).Infof("throwing away msg %v for being too old: %v > %v", msg.Message, msg.Timestamp.String(), lookback.String())
+				continue
+			}
+
+			k.logCh <- &logtypes.Log{
+				Message:   strings.TrimSpace(msg.Message),
+				Timestamp: msg.Timestamp,
+			}
+		}
+	}
+}

--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_test.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmsg
+
+import (
+	"io"
+	"testing"
+
+	"code.cloudfoundry.org/clock/fakeclock"
+	"github.com/euank/go-kmsg-parser/kmsgparser"
+	"github.com/stretchr/testify/assert"
+
+	"time"
+
+	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
+	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
+)
+
+type mockKmsgParser struct {
+	kmsgs []kmsgparser.Message
+}
+
+func (m *mockKmsgParser) SetLogger(kmsgparser.Logger) {}
+func (m *mockKmsgParser) Close() error                { return nil }
+func (m *mockKmsgParser) Parse() <-chan kmsgparser.Message {
+	c := make(chan kmsgparser.Message)
+	go func() {
+		for _, msg := range m.kmsgs {
+			c <- msg
+		}
+	}()
+	return c
+}
+func (m *mockKmsgParser) SeekEnd() error { return nil }
+
+func TestWatch(t *testing.T) {
+	now := time.Date(time.Now().Year(), time.January, 2, 3, 4, 5, 0, time.Local)
+	fakeClock := fakeclock.NewFakeClock(now)
+	testCases := []struct {
+		log      *mockKmsgParser
+		logs     []logtypes.Log
+		lookback string
+	}{
+		{
+			// The start point is at the head of the log file.
+			log: &mockKmsgParser{kmsgs: []kmsgparser.Message{
+				{Message: "1", Timestamp: now.Add(0 * time.Second)},
+				{Message: "2", Timestamp: now.Add(1 * time.Second)},
+				{Message: "3", Timestamp: now.Add(2 * time.Second)},
+			}},
+			logs: []logtypes.Log{
+				{
+					Timestamp: now,
+					Message:   "1",
+				},
+				{
+					Timestamp: now.Add(time.Second),
+					Message:   "2",
+				},
+				{
+					Timestamp: now.Add(2 * time.Second),
+					Message:   "3",
+				},
+			},
+			lookback: "0",
+		},
+		{
+			// The start point is in the middle of the log file.
+			log: &mockKmsgParser{kmsgs: []kmsgparser.Message{
+				{Message: "1", Timestamp: now.Add(-1 * time.Second)},
+				{Message: "2", Timestamp: now.Add(0 * time.Second)},
+				{Message: "3", Timestamp: now.Add(1 * time.Second)},
+			}},
+			logs: []logtypes.Log{
+				{
+					Timestamp: now,
+					Message:   "2",
+				},
+				{
+					Timestamp: now.Add(time.Second),
+					Message:   "3",
+				},
+			},
+			lookback: "0",
+		},
+		{
+			// The start point is at the end of the log file, but we look back.
+			log: &mockKmsgParser{kmsgs: []kmsgparser.Message{
+				{Message: "1", Timestamp: now.Add(-2 * time.Second)},
+				{Message: "2", Timestamp: now.Add(-1 * time.Second)},
+				{Message: "3", Timestamp: now.Add(0 * time.Second)},
+			}},
+			lookback: "1s",
+			logs: []logtypes.Log{
+				{
+					Timestamp: now.Add(-time.Second),
+					Message:   "2",
+				},
+				{
+					Timestamp: now,
+					Message:   "3",
+				},
+			},
+		},
+	}
+	for _, test := range testCases {
+		w := NewKmsgWatcher(types.WatcherConfig{Lookback: test.lookback})
+		w.(*kernelLogWatcher).clock = fakeClock
+		w.(*kernelLogWatcher).kmsgParser = test.log
+		logCh, err := w.Watch()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer w.Stop()
+		for _, expected := range test.logs {
+			got := <-logCh
+			assert.Equal(t, &expected, got)
+		}
+		// The log channel should have already been drained
+		// There could stil be future messages sent into the channel, but the chance is really slim.
+		timeout := time.After(100 * time.Millisecond)
+		select {
+		case log := <-logCh:
+			t.Errorf("unexpected extra log: %+v", *log)
+		case <-timeout:
+		}
+	}
+}
+
+type fakeKmsgReader struct {
+	logLines []string
+}
+
+func (r *fakeKmsgReader) Read(data []byte) (int, error) {
+	if len(r.logLines) == 0 {
+		return 0, io.EOF
+	}
+	l := r.logLines[0]
+	r.logLines = r.logLines[1:]
+	copy(data, []byte(l))
+	return len(l), nil
+}
+
+func (r *fakeKmsgReader) Close() error {
+	return nil
+}

--- a/pkg/systemlogmonitor/logwatchers/register_kmsg.go
+++ b/pkg/systemlogmonitor/logwatchers/register_kmsg.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logwatchers
+
+import "k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/kmsg"
+
+func init() {
+	registerLogWatcher("kmsg", kmsg.NewKmsgWatcher)
+}

--- a/vendor/github.com/euank/go-kmsg-parser/LICENSE
+++ b/vendor/github.com/euank/go-kmsg-parser/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/euank/go-kmsg-parser/kmsgparser/kmsgparser.go
+++ b/vendor/github.com/euank/go-kmsg-parser/kmsgparser/kmsgparser.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2016 Euan Kemp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kmsgparser implements a parser for the Linux `/dev/kmsg` format.
+// More information about this format may be found here:
+// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+// Some parts of it are slightly inspired by rsyslog's contrib module:
+// https://github.com/rsyslog/rsyslog/blob/v8.22.0/contrib/imkmsg/kmsg.c
+package kmsgparser
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Parser is a parser for the kernel ring buffer found at /dev/kmsg
+type Parser interface {
+	// SeekEnd moves the parser to the end of the kmsg queue.
+	SeekEnd() error
+	// Parse provides a channel of messages read from the kernel ring buffer.
+	// When first called, it will read the existing ringbuffer, after which it will emit new messages as they occur.
+	Parse() <-chan Message
+	// SetLogger sets the logger that will be used to report malformed kernel
+	// ringbuffer lines or unexpected kmsg read errors.
+	SetLogger(Logger)
+	// Close closes the underlying kmsg reader for this parser
+	Close() error
+}
+
+// Message represents a given kmsg logline, including its timestamp (as
+// calculated based on offset from boot time), its possibly multi-line body,
+// and so on. More information about these mssages may be found here:
+// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+type Message struct {
+	Priority       int
+	SequenceNumber int
+	Timestamp      time.Time
+	Message        string
+}
+
+func NewParser() (Parser, error) {
+	f, err := os.Open("/dev/kmsg")
+	if err != nil {
+		return nil, err
+	}
+
+	bootTime, err := getBootTime()
+	if err != nil {
+		return nil, err
+	}
+
+	return &parser{
+		log:        &StandardLogger{nil},
+		kmsgReader: f,
+		bootTime:   bootTime,
+	}, nil
+}
+
+type ReadSeekCloser interface {
+	io.ReadCloser
+	io.Seeker
+}
+
+type parser struct {
+	log        Logger
+	kmsgReader ReadSeekCloser
+	bootTime   time.Time
+}
+
+func getBootTime() (time.Time, error) {
+	var sysinfo syscall.Sysinfo_t
+	err := syscall.Sysinfo(&sysinfo)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("could not get boot time: %v", err)
+	}
+	// sysinfo only has seconds
+	return time.Now().Add(-1 * (time.Duration(sysinfo.Uptime) * time.Second)), nil
+}
+
+func (p *parser) SetLogger(log Logger) {
+	p.log = log
+}
+
+func (p *parser) Close() error {
+	return p.kmsgReader.Close()
+}
+
+func (p *parser) SeekEnd() error {
+	_, err := p.kmsgReader.Seek(0, os.SEEK_END)
+	return err
+}
+
+// Parse will read from the provided reader and provide a channel of messages
+// parsed.
+// If the provided reader *is not* a proper Linux kmsg device, Parse might not
+// behave correctly since it relies on specific behavior of `/dev/kmsg`
+//
+// A goroutine is created to process the provided reader. The goroutine will
+// exit when the given reader is closed.
+// Closing the passed in reader will cause the goroutine to exit.
+func (p *parser) Parse() <-chan Message {
+
+	output := make(chan Message, 1)
+
+	go func() {
+		defer close(output)
+		msg := make([]byte, 8192)
+		for {
+			// Each read call gives us one full message.
+			// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+			n, err := p.kmsgReader.Read(msg)
+			if err != nil {
+				if err == syscall.EPIPE {
+					p.log.Warningf("short read from kmsg; skipping")
+					continue
+				}
+
+				if err == io.EOF {
+					p.log.Infof("kmsg reader closed, shutting down")
+					return
+				}
+
+				p.log.Errorf("error reading /dev/kmsg: %v", err)
+				return
+			}
+
+			msgStr := string(msg[:n])
+
+			message, err := p.parseMessage(msgStr)
+			if err != nil {
+				p.log.Warningf("unable to parse kmsg message %q: %v", msgStr, err)
+				continue
+			}
+
+			output <- message
+		}
+	}()
+
+	return output
+}
+
+func (p *parser) parseMessage(input string) (Message, error) {
+	// Format:
+	//   PRIORITY,SEQUENCE_NUM,TIMESTAMP,-;MESSAGE
+	parts := strings.SplitN(input, ";", 2)
+	if len(parts) != 2 {
+		return Message{}, fmt.Errorf("invalid kmsg; must contain a ';'")
+	}
+
+	metadata, message := parts[0], parts[1]
+
+	metadataParts := strings.Split(metadata, ",")
+	if len(metadataParts) < 3 {
+		return Message{}, fmt.Errorf("invalid kmsg: must contain at least 3 ',' separated pieces at the start")
+	}
+
+	priority, sequence, timestamp := metadataParts[0], metadataParts[1], metadataParts[2]
+
+	prioNum, err := strconv.Atoi(priority)
+	if err != nil {
+		return Message{}, fmt.Errorf("could not parse %q as priority: %v", priority, err)
+	}
+
+	sequenceNum, err := strconv.Atoi(sequence)
+	if err != nil {
+		return Message{}, fmt.Errorf("could not parse %q as sequence number: %v", priority, err)
+	}
+
+	timestampUsFromBoot, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return Message{}, fmt.Errorf("could not parse %q as timestamp: %v", priority, err)
+	}
+	// timestamp is offset in microsecond from boottime.
+	msgTime := p.bootTime.Add(time.Duration(timestampUsFromBoot) * time.Microsecond)
+
+	return Message{
+		Priority:       prioNum,
+		SequenceNumber: sequenceNum,
+		Timestamp:      msgTime,
+		Message:        message,
+	}, nil
+}

--- a/vendor/github.com/euank/go-kmsg-parser/kmsgparser/log.go
+++ b/vendor/github.com/euank/go-kmsg-parser/kmsgparser/log.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2016 Euan Kemp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kmsgparser
+
+import stdlog "log"
+
+// Logger is a glog compatible logging interface
+// The StandardLogger struct can be used to wrap a log.Logger from the golang
+// "log" package to create a standard a logger fulfilling this interface as
+// well.
+type Logger interface {
+	Warningf(string, ...interface{})
+	Infof(string, ...interface{})
+	Errorf(string, ...interface{})
+}
+
+// StandardLogger adapts the "log" package's Logger interface to be a Logger
+type StandardLogger struct {
+	*stdlog.Logger
+}
+
+func (s *StandardLogger) Warningf(fmt string, args ...interface{}) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Printf("[WARNING] "+fmt, args)
+}
+
+func (s *StandardLogger) Infof(fmt string, args ...interface{}) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Printf("[INFO] "+fmt, args)
+}
+
+func (s *StandardLogger) Errorf(fmt string, args ...interface{}) {
+	if s.Logger == nil {
+		return
+	}
+	s.Logger.Printf("[INFO] "+fmt, args)
+}


### PR DESCRIPTION
All the other loggers (afaik), like rsyslog and journald and what have you, simply read `/dev/kmsg`.

It's probably easier for everyone if we just read that directly too!

I put together a bit of code doing so [over here](https://github.com/euank/go-kmsg-parser/blob/v1.0.0/kmsgparser/kmsgparser.go), and this commit leverages that code for the node-problem-detector.

I plan to replace cadvisor's similar hacky log parsing with the same code as well.

So, what are the implications?
Well, one thing this can't do as well is read far into the past. This can't read further back than the ring buffer extends, so on startup it's quite possible it won't get as many old messages. That means really large lookback values will behave differently now because they'll read less.

That could have already happened depending on logrotation policy, but now it's a lot harder for the user to control (kernel dmesg size is much harder to change :).

However, I think the significant simplicity and cross-distro gains by doing this are worth it.

~~I also preemptively removed the old integrations as I think this makes them fully redundant, as well as the translators thingy since why would you want to translate when you're reading the one and only true source?~~

Edit: I added this as an additional plugin, but didn't change any defaults or such.

Fixes #14 #39 

cc @Random-Liu @AdoHe @derekwaynecarr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/41)
<!-- Reviewable:end -->
