### PR TITLE
Added functionality for "hollow"-node-problem-detector

### DIFF
--- a/Dockerfile_template
+++ b/Dockerfile_template
@@ -15,5 +15,5 @@
 FROM alpine:3.4
 MAINTAINER Random Liu <lantaol@google.com>
 ADD ./bin/node-problem-detector /node-problem-detector
-ADD config /config
+ADD {{config_directory}} /config
 ENTRYPOINT ["/node-problem-detector", "--kernel-monitor=/config/kernel-monitor.json"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all container push clean node-problem-detector
+.PHONY: all container hollow-container push hollow-push clean node-problem-detector
 
 all: push
 
@@ -7,21 +7,35 @@ TAG = v0.2
 
 PROJ = google_containers
 
+# TODO(shyamjvs) : Change this to google_containers once the hollow-node-problem-detector is tested fine.
+TEST_PROJ = shyamjvs-k8s-km1
+
 PKG_SOURCES := $(shell find pkg -name '*.go')
 
 node-problem-detector: ./bin/node-problem-detector
 
 ./bin/node-problem-detector: $(PKG_SOURCES) node_problem_detector.go
-	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o node-problem-detector
+	CGO_ENABLED=1 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o ./bin/node-problem-detector
 
 test:
 	go test -timeout=1m -v -race ./pkg/...
 
 container: node-problem-detector
+	cp Dockerfile_template Dockerfile
+	sed -i -e "s@{{config_directory}}@config@g" Dockerfile
 	docker build -t gcr.io/$(PROJ)/node-problem-detector:$(TAG) .
+
+hollow-container: node-problem-detector
+	cp Dockerfile_template Dockerfile
+	sed -i -e "s@{{config_directory}}@hollow_config@g" Dockerfile
+	docker build -t gcr.io/$(TEST_PROJ)/node-problem-detector:$(TAG) .
 
 push: container
 	gcloud docker push gcr.io/$(PROJ)/node-problem-detector:$(TAG)
 
+hollow-push: hollow-container
+	gcloud docker push gcr.io/$(TEST_PROJ)/node-problem-detector:$(TAG)
+
 clean:
 	rm -f ./bin/node-problem-detector
+	rm -f ./Dockerfile

--- a/hollow_config/kernel-monitor.json
+++ b/hollow_config/kernel-monitor.json
@@ -1,0 +1,9 @@
+{
+	"logPath": "/log/kern.log",
+	"lookback": "10m",
+	"startPattern": "Initializing cgroup subsys cpuset",
+	"bufferSize": 10,
+	"source": "kernel-monitor",
+	"conditions": [],
+	"rules": []
+}


### PR DESCRIPTION
This PR fixes issue #50 
Made the following changes in order to incorporate creation and pushing of a hollow-node-problem-detector image to gcr:
1. Created a hollow KernelMonitor config with empty rule and condition lists
2. Converted Dockerfile to a template which can take path to kernelMonitor config as input
3. Added new targets to Makefile for hollow-node-problem-detector

cc @kubernetes/sig-scalability @wojtek-t @gmarek @Random-Liu 