### PR TITLE
change travis config script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/bin/node-problem-detector
+/node-problem-detector

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
  - cd $HOME/gopath/src/k8s.io/node-problem-detector
 script:
  - make test
- - go build -race
+ - make node-problem-detector 

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,8 @@ PROJ = google_containers
 
 PKG_SOURCES := $(shell find pkg -name '*.go')
 
-node-problem-detector: ./bin/node-problem-detector
-
-./bin/node-problem-detector: $(PKG_SOURCES) node_problem_detector.go
-	CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o node-problem-detector
+node-problem-detector: $(PKG_SOURCES) node_problem_detector.go
+	GOOS=linux go build -ldflags '-w -extldflags "-static"' -o node-problem-detector
 
 test:
 	go test -timeout=1m -v -race ./pkg/...
@@ -24,4 +22,4 @@ push: container
 	gcloud docker push gcr.io/$(PROJ)/node-problem-detector:$(TAG)
 
 clean:
-	rm -f ./bin/node-problem-detector
+	rm -f node-problem-detector


### PR DESCRIPTION
Currently, `make node-problem-detector` error with the following message: 

```
CGO_ENABLED=0 GOOS=linux godep go build -a -installsuffix cgo -ldflags '-w' -o node-problem-detector
vendor/github.com/coreos/go-systemd/sdjournal/functions.go:19:2: no buildable Go source files in /home/xiening/go/src/k8s.io/node-problem-detector/vendor/github.com/coreos/pkg/dlopen
godep: go exit status 1
Makefile:15: recipe for target 'bin/node-problem-detector' failed
make: *** [bin/node-problem-detector] Error 1
```

`dlopen` uses cgo to compile. So, we should turn on `CGO_ENABLED`. 

In order to make node-problem-detector statically linked. We can use `-extldflags "-static" `

* remove `./bin/node-problem-detector` target. IMO, it will not work as expected. It will not generate node-problem-detector binary under `bin` directory.
* change `go build -race` script to `make node-problem-detector`
* add `dep` target, it seems travis ci does not add godep binary automatically. So, we will check it and if it does not exist, we will manually download it.
* Enable cgo, because we dlopen uses it to compile. 
* In order to compile a statically linked binary. we may should use `-extldflags "-static"`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/54)
<!-- Reviewable:end -->
