### PR TITLE
Remove dead code in kernel monitor

### DIFF
--- a/pkg/kernelmonitor/kernel_monitor.go
+++ b/pkg/kernelmonitor/kernel_monitor.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"regexp"
-	"syscall"
 	"time"
 
 	kerntypes "k8s.io/node-problem-detector/pkg/kernelmonitor/types"
@@ -81,11 +80,6 @@ func NewKernelMonitorOrDie(configPath string) KernelMonitor {
 		panic(err)
 	}
 	glog.Infof("Finish parsing log file: %+v", k.config)
-	var info syscall.Sysinfo_t
-	err = syscall.Sysinfo(&info)
-	if err != nil {
-		panic(err)
-	}
 	k.watcher = NewKernelLogWatcher(k.config.WatcherConfig)
 	k.buffer = NewLogBuffer(k.config.BufferSize)
 	// A 1000 size channel should be big enough.


### PR DESCRIPTION
Check for `linux` os with `runtime.GOOS` instead of `syscall.Sysinfo_t` which is not available on MacOS.

This will is possible to develop and `make node-problem-detector` on MacOS when #39 is merged with supporting disable `systemd` with an environment variable.

All available `runtime.GOOS` values can be found in [this page](https://golang.org/doc/install/source#environment).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/55)
<!-- Reviewable:end -->
