### PR TITLE
Fix the dockerfile to use the right binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@
 
 FROM alpine:3.4
 MAINTAINER Random Liu <lantaol@google.com>
-ADD ./bin/node-problem-detector /node-problem-detector
+ADD ./node-problem-detector /node-problem-detector
 ADD config /config
 ENTRYPOINT ["/node-problem-detector", "--kernel-monitor=/config/kernel-monitor.json"]


### PR DESCRIPTION
@andyxning Could you help me review this?

I found we missed the Dockerfile in https://github.com/kubernetes/node-problem-detector/pull/54.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/56)
<!-- Reviewable:end -->
