### PR TITLE
Add CHANGELOG.md for NPD repo.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- Add travis presubmit test.
+
+### Changed
+- Update kubernetes version to v1.4.0-beta.3
+
+## [0.2.0] - 2016-08-23
+### Added
+- Add look back support in kernel monitor. Kernel monitor will look back for
+  specified amount of time to detect old problems during each start or restart.
+- Add support for some kernel oops detection.
+
+### Changed
+- Change NPD to get node name from `NODE_NAME` env first before `os.Hostname`,
+  and update the example to get node name from downward api and set `NODE_NAME`.
+
+## 0.1.0 - 2016-06-09
+### Added
+- Initial version of node problem detector.
+
+[Unreleased]: https://github.com/kubernetes/node-problem-detector/compare/v0.2...HEAD
+[0.2.0]: https://github.com/kubernetes/node-problem-detector/compare/v0.1...v0.2


### PR DESCRIPTION
Fixes https://github.com/kubernetes/node-problem-detector/issues/45.
For https://github.com/kubernetes/node-problem-detector/issues/58.

This PR adds a CHANGELOG.md for NPD repo.

The format follows http://keepachangelog.com/.
@jfilak Thanks for your awesome suggestion! :)

@jfilak @andyxning Can you help me review this PR? Thanks a lot!

/cc @dchen1107 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/66)
<!-- Reviewable:end -->
