### PR TITLE
Add --version flag.

### DIFF
--- a/cmd/node_problem_detector.go
+++ b/cmd/node_problem_detector.go
@@ -19,16 +19,20 @@ package main
 import (
 	"flag"
 	"net/url"
+	"os"
 
 	"k8s.io/node-problem-detector/pkg/kernelmonitor"
 	"k8s.io/node-problem-detector/pkg/problemdetector"
+	"k8s.io/node-problem-detector/pkg/version"
 
 	"github.com/golang/glog"
 )
 
+// TODO: Move flags to options directory.
 var (
 	kernelMonitorConfigPath = flag.String("kernel-monitor", "/config/kernel-monitor.json", "The path to the kernel monitor config file")
-	apiServerOverride       = flag.String("apiserver-override", "", "custom URI used to connect to Kubernetes ApiServer")
+	apiServerOverride       = flag.String("apiserver-override", "", "Custom URI used to connect to Kubernetes ApiServer")
+	printVersion            = flag.Bool("version", false, "Print version information and quit")
 )
 
 func validateCmdParams() {
@@ -40,6 +44,11 @@ func validateCmdParams() {
 func main() {
 	flag.Parse()
 	validateCmdParams()
+
+	if *printVersion {
+		version.PrintVersion()
+		os.Exit(0)
+	}
 
 	k := kernelmonitor.NewKernelMonitorOrDie(*kernelMonitorConfigPath)
 	p := problemdetector.NewProblemDetector(k, *apiServerOverride)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import "fmt"
+
+// version defines the version
+var version string = "UNKNOWN"
+
+func PrintVersion() {
+	fmt.Println(version)
+}


### PR DESCRIPTION
Add `--version` flag, which is useful for standalone NPD.

The version format is using `git describe --tags --dirty`.

Current version is like this:
```
$ make version
v0.2.0-39-gaedb371

$ ./node-problem-detector --version
v0.2.0-39-gaedb371
```

/cc @dchen1107 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/71)
<!-- Reviewable:end -->
