### PR TITLE
Add release tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/node-problem-detector
+/bin/node-problem-detector

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: trusty
 language: go
 go:
  - 1.6
+ - 1.7
+services:
+ - docker
 before_install:
  - sudo apt-get -qq update
  - sudo apt-get install -y libsystemd-journal-dev
@@ -14,4 +17,4 @@ install:
  - cd $HOME/gopath/src/k8s.io/node-problem-detector
 script:
  - make test
- - make node-problem-detector 
+ - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@
 
 FROM alpine:3.4
 MAINTAINER Random Liu <lantaol@google.com>
-ADD ./node-problem-detector /node-problem-detector
+ADD ./bin/node-problem-detector /node-problem-detector
 ADD config /config
 ENTRYPOINT ["/node-problem-detector", "--kernel-monitor=/config/kernel-monitor.json"]

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,7 +15,7 @@ package version
 
 import "fmt"
 
-// version defines the version
+// version defines node-problem-detector version string.
 var version string = "UNKNOWN"
 
 func PrintVersion() {


### PR DESCRIPTION
Based on #71.

Add release tarball and more command in the Makefile. The name of the tarball is `node-problem-detector-$(VERSION).tar.gz`.

For my local dirty directory, it's `node-problem-detector-v0.2.0-40-gb3b72c5-dirty.tar.gz`. For a newly tagged release, it should be `node-problem-detector-v0.3.0.tar.gz`.

```
make build-container # Build the container
make build-tar # Build the tarball
make build # Build both the container and the tarball.
make push-container # Push the container to image registry
make push-tar # Push the tarball to cloud storage
make push # Push both the container and the tarball
```

The tarball will be used to deploy standalone NPD in kubernetes cluster.

@andyxning Could you help me review this? Since you are quite familiar with the Makefile. :)
/cc @dchen1107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/74)
<!-- Reviewable:end -->
