### PR TITLE
Made authFile override logic not fallback to in-cluster config

### DIFF
--- a/vendor/k8s.io/heapster/common/kubernetes/configs.go
+++ b/vendor/k8s.io/heapster/common/kubernetes/configs.go
@@ -104,9 +104,19 @@ func GetKubeClientConfig(uri *url.URL) (*kube_client.Config, error) {
 		}
 
 		if authFile != "" {
-			if kubeConfig, err = kubeClientCmd.NewNonInteractiveDeferredLoadingClientConfig(
-				&kubeClientCmd.ClientConfigLoadingRules{ExplicitPath: authFile},
-				configOverrides).ClientConfig(); err != nil {
+			// Load structured kubeconfig data from the given path.
+			loader := &clientcmd.ClientConfigLoadingRules{ExplicitPath: authFile}
+			loadedConfig, err := loader.Load()
+			if err != nil {
+				return nil, err
+			}
+
+			// Flatten the loaded data to a particular restclient.Config based on the current context.
+			if kubeConfig, err = clientcmd.NewNonInteractiveClientConfig(
+				*loadedConfig,
+				loadedConfig.CurrentContext,
+				&clientcmd.ConfigOverrides{},
+				loader).ClientConfig(); err != nil {
 				return nil, err
 			}
 		} else {


### PR DESCRIPTION
Fixes #73 

Changed the function `GetKubeClientConfig`  to use `NewNonInteractiveClientConfig` instead of `NewNonInteractiveDeferredLoadingClientConfig` as we do not want to fallback to in-cluster-config if authFile is specified.
(Inspired from this example https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/bootstrap.go#L149)
We would also want to have such a similar change in heapster.

cc @Random-Liu @andyxning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/75)
<!-- Reviewable:end -->
