### PR TITLE
change apiserver-override argument from long option format to short o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ List of supported problem daemons:
 
 # Usage
 ## Flags
-* `--apiserver-override`: A URI parameter used to customize how node-problem-detector
+* `-apiserver-override`: A URI parameter used to customize how node-problem-detector
 connects the apiserver. The format is same as the
 [`source`](https://github.com/kubernetes/heapster/blob/master/docs/source-configuration.md#kubernetes)
 flag of [Heapster](https://github.com/kubernetes/heapster).


### PR DESCRIPTION
change apiserver-override from long option format to short option format. I.e.:
`--apiserver-override` -> `-apiserver-override`

This makes README being coherent with the output of `node-problem-detector -h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/78)
<!-- Reviewable:end -->
