### PR TITLE
Add doc for `-kernel-monitor` and `-version` flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ List of supported problem daemons:
 
 # Usage
 ## Flags
+* `-version`: Print current version of node-problem-detector.
+* `-kernel-monitor`: The configuration used by the kernel monitor, e.g.
+  [config/kernel-monitor.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json).
 * `-apiserver-override`: A URI parameter used to customize how node-problem-detector
 connects the apiserver. The format is same as the
 [`source`](https://github.com/kubernetes/heapster/blob/master/docs/source-configuration.md#kubernetes)


### PR DESCRIPTION
This PR added documentation about the flags `-version` and `-kernel-monitor` in README.md.

@andyxning Could you help me review this 3 line change? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/80)
<!-- Reviewable:end -->
