### PR TITLE
Fix kernel monitor issues

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -1,8 +1,7 @@
 {
 	"plugin": "journald",
 	"logPath": "/var/log/journal",
-	"lookback": "10m",
-	"startPattern": "Initializing cgroup subsys cpuset",
+	"lookback": "5m",
 	"bufferSize": 10,
 	"source": "kernel-monitor",
 	"conditions": [
@@ -25,12 +24,17 @@
 		},
 		{
 			"type": "temporary",
-			"reason": "KernelPanic",
+			"reason": "UnregisterNetDevice",
+			"pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
+		},
+		{
+			"type": "temporary",
+			"reason": "KernelOops",
 			"pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
 		},
 		{
 			"type": "temporary",
-			"reason": "KernelPanic",
+			"reason": "KernelOops",
 			"pattern": "divide error: 0000 \\[#\\d+\\] SMP"
 		},
 		{
@@ -44,12 +48,6 @@
 			"condition": "KernelDeadlock",
 			"reason": "DockerHung",
 			"pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
-		},
-		{
-			"type": "permanent",
-			"condition": "KernelDeadlock",
-			"reason": "UnregisterNetDeviceIssue",
-			"pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
 		}
 	]
 }

--- a/pkg/kernelmonitor/config.go
+++ b/pkg/kernelmonitor/config.go
@@ -34,8 +34,6 @@ type MonitorConfig struct {
 	DefaultConditions []types.Condition `json:"conditions"`
 	// Rules are the rules kernel monitor will follow to parse the log file.
 	Rules []kerntypes.Rule `json:"rules"`
-	// StartPattern is the pattern of the start line
-	StartPattern string `json:"startPattern, omitempty"`
 }
 
 // applyDefaultConfiguration applies default configurations.

--- a/pkg/kernelmonitor/logwatchers/log_watchers.go
+++ b/pkg/kernelmonitor/logwatchers/log_watchers.go
@@ -17,8 +17,6 @@ limitations under the License.
 package logwatchers
 
 import (
-	"fmt"
-
 	"k8s.io/node-problem-detector/pkg/kernelmonitor/logwatchers/types"
 
 	"github.com/golang/glog"
@@ -32,12 +30,13 @@ func registerLogWatcher(name string, create types.WatcherCreateFunc) {
 	createFuncs[name] = create
 }
 
-// GetLogWatcher get a log watcher based on the passed in configuration.
-func GetLogWatcher(config types.WatcherConfig) (types.LogWatcher, error) {
+// GetLogWatcherOrDie get a log watcher based on the passed in configuration.
+// The function panics when encounts an error.
+func GetLogWatcherOrDie(config types.WatcherConfig) types.LogWatcher {
 	create, ok := createFuncs[config.Plugin]
 	if !ok {
-		return nil, fmt.Errorf("no create function found for plugin %q", config.Plugin)
+		glog.Fatalf("No create function found for plugin %q", config.Plugin)
 	}
 	glog.Infof("Use log watcher of plugin %q", config.Plugin)
-	return create(config), nil
+	return create(config)
 }

--- a/pkg/kernelmonitor/logwatchers/register_syslog.go
+++ b/pkg/kernelmonitor/logwatchers/register_syslog.go
@@ -24,5 +24,5 @@ const syslogPluginName = "syslog"
 
 func init() {
 	// Register the syslog plugin.
-	registerLogWatcher(syslogPluginName, syslog.NewSyslogWatcher)
+	registerLogWatcher(syslogPluginName, syslog.NewSyslogWatcherOrDie)
 }


### PR DESCRIPTION
Based on https://github.com/kubernetes/node-problem-detector/pull/39. Will rebase after https://github.com/kubernetes/node-problem-detector/pull/39 gets merged.

Only the last commit is new.

This PR:
* Change `unregister_netdevice` to be an event to fix #47. /cc @euank 
* Change `KernelPanic` to `KernelOops` because we can't really handle kernel panic by simply parsing kernel log.
  * We can consider supporting [`ramoops`](http://lxr.free-electrons.com/source/Documentation/ramoops.txt), but GCE doesn't support it now.
  * Other options are to use `serial console` or `PVPANIC`, but it could not be achieved inside the node scope. We may introduce a cluster level node health monitoring component in the future.
* Use system boot time instead of [`StartPattern`](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json#L4) to fix #48 /cc @euank . Since `KernelPanic` is not in the scope any more, we can only care about current boot now.

/cc @dchen1107 @jfilak

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/81)
<!-- Reviewable:end -->
