### PR TITLE
correct spelling error in kernel_monitor.go

### DIFF
--- a/pkg/kernelmonitor/kernel_monitor.go
+++ b/pkg/kernelmonitor/kernel_monitor.go
@@ -181,7 +181,7 @@ func (k *kernelMonitor) generateStatus(logs []*kerntypes.KernelLog, rule kerntyp
 func (k *kernelMonitor) initializeStatus() {
 	// Initialize the default node conditions
 	k.conditions = initialConditions(k.config.DefaultConditions)
-	glog.Infof("Initalize condition generated: %+v", k.conditions)
+	glog.Infof("Initialize condition generated: %+v", k.conditions)
 	// Update the initial status
 	k.output <- &types.Status{
 		Source:     k.config.Source,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/82)
<!-- Reviewable:end -->
