### PR TITLE
Add NPD endpoints: /debug/pprof, /healthz, /conditions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ version:
 
 ./bin/node-problem-detector: $(PKG_SOURCES)
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux go build -o bin/node-problem-detector \
-	     -ldflags '-w -X $(PKG)/pkg/version.version=$(VERSION)' \
+	     -ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
 	     $(BUILD_TAGS) cmd/node_problem_detector.go
 
 Dockerfile: Dockerfile.in

--- a/pkg/condition/manager.go
+++ b/pkg/condition/manager.go
@@ -54,19 +54,27 @@ type ConditionManager interface {
 	Start()
 	// UpdateCondition updates a specific condition.
 	UpdateCondition(types.Condition)
+	// GetConditions returns all current conditions.
+	GetConditions() []types.Condition
 }
 
 type conditionManager struct {
+	// Only 2 fields will be accessed by more than one goroutines at the same time:
+	// * `updates`: updates will be written by random caller and the sync routine,
+	// so it needs to be protected by write lock in both `UpdateCondition` and
+	// `needUpdates`.
+	// * `conditions`: conditions will only be written in the sync routine, but
+	// it will be read by random caller and the sync routine. So it needs to be
+	// protected by write lock in `needUpdates` and read lock in `GetConditions`.
+	// No lock is needed in `sync`, because it is in the same goroutine with the
+	// write operation.
+	sync.RWMutex
 	clock        clock.Clock
 	latestTry    time.Time
 	resyncNeeded bool
 	client       problemclient.Client
-	// updatesLock is the lock protecting updates. Only the field `updates`
-	// will be accessed by random caller and the sync routine, so only it
-	// needs to be protected.
-	updatesLock sync.Mutex
-	updates     map[string]types.Condition
-	conditions  map[string]types.Condition
+	updates      map[string]types.Condition
+	conditions   map[string]types.Condition
 }
 
 // NewConditionManager creates a condition manager.
@@ -84,11 +92,21 @@ func (c *conditionManager) Start() {
 }
 
 func (c *conditionManager) UpdateCondition(condition types.Condition) {
-	c.updatesLock.Lock()
-	defer c.updatesLock.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	// New node condition will override the old condition, because we only need the newest
 	// condition for each condition type.
 	c.updates[condition.Type] = condition
+}
+
+func (c *conditionManager) GetConditions() []types.Condition {
+	c.RLock()
+	defer c.RUnlock()
+	var conditions []types.Condition
+	for _, condition := range c.conditions {
+		conditions = append(conditions, condition)
+	}
+	return conditions
 }
 
 func (c *conditionManager) syncLoop() {
@@ -105,8 +123,8 @@ func (c *conditionManager) syncLoop() {
 
 // needUpdates checks whether there are recent updates.
 func (c *conditionManager) needUpdates() bool {
-	c.updatesLock.Lock()
-	defer c.updatesLock.Unlock()
+	c.Lock()
+	defer c.Unlock()
 	needUpdate := false
 	for t, update := range c.updates {
 		if !reflect.DeepEqual(c.conditions[t], update) {

--- a/pkg/condition/manager_test.go
+++ b/pkg/condition/manager_test.go
@@ -81,6 +81,18 @@ func TestNeedUpdates(t *testing.T) {
 	}
 }
 
+func TestGetConditions(t *testing.T) {
+	m, _, _ := newTestManager()
+	assert.Empty(t, m.GetConditions())
+	testCondition1 := newTestCondition("TestCondition1")
+	testCondition2 := newTestCondition("TestCondition2")
+	m.UpdateCondition(testCondition1)
+	m.UpdateCondition(testCondition2)
+	assert.True(t, m.needUpdates())
+	assert.Contains(t, m.GetConditions(), testCondition1)
+	assert.Contains(t, m.GetConditions(), testCondition2)
+}
+
 func TestResync(t *testing.T) {
 	m, fakeClient, fakeClock := newTestManager()
 	condition := newTestCondition("TestCondition")

--- a/pkg/problemdetector/problem_detector.go
+++ b/pkg/problemdetector/problem_detector.go
@@ -17,6 +17,8 @@ limitations under the License.
 package problemdetector
 
 import (
+	"net/http"
+
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/util/clock"
@@ -30,6 +32,7 @@ import (
 // ProblemDetector collects statuses from all problem daemons and update the node condition and send node event.
 type ProblemDetector interface {
 	Run() error
+	RegisterHTTPHandlers()
 }
 
 type problemDetector struct {
@@ -69,4 +72,12 @@ func (p *problemDetector) Run() error {
 			}
 		}
 	}
+}
+
+// RegisterHTTPHandlers registers http handlers of node problem detector.
+func (p *problemDetector) RegisterHTTPHandlers() {
+	// Add the handler to serve condition http request.
+	http.HandleFunc("/conditions", func(w http.ResponseWriter, r *http.Request) {
+		util.ReturnHTTPJson(w, p.conditionManager.GetConditions())
+	})
 }

--- a/pkg/util/http.go
+++ b/pkg/util/http.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ReturnHTTPJson generates json http response.
+func ReturnHTTPJson(w http.ResponseWriter, object interface{}) {
+	data, err := json.Marshal(object)
+	if err != nil {
+		ReturnHTTPError(w, err)
+		return
+	}
+	w.Header().Set("Content-type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
+}
+
+// ReturnHTTPError generates error http response.
+func ReturnHTTPError(w http.ResponseWriter, err error) {
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte(err.Error()))
+}


### PR DESCRIPTION
For https://github.com/kubernetes/node-problem-detector/issues/76.

This PR:
* Added `/healthz` for health checking. Currently it always returns 200.
* Added `/conditions` to list all internal conditions inside the NPD. This is mainly used for debugging.
* Added `/debug/pprof` pprof endpoint. This will be used for following performance benchmark and optimization.

Note that to get more debug information, we removed the `-w` ldflag. The binary size only increased from 40MB+ to 60MB+, which should be fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/83)
<!-- Reviewable:end -->
