### PR TITLE
Only change transition timestamp when condition is changed.

### DIFF
--- a/pkg/kernelmonitor/kernel_monitor.go
+++ b/pkg/kernelmonitor/kernel_monitor.go
@@ -161,10 +161,15 @@ func (k *kernelMonitor) generateStatus(logs []*kerntypes.KernelLog, rule kerntyp
 			condition := &k.conditions[i]
 			if condition.Type == rule.Condition {
 				condition.Type = rule.Condition
+				// Update transition timestamp and message when the condition
+				// changes. Condition is considered to be changed only when
+				// status or reason changes.
+				if !condition.Status || condition.Reason != rule.Reason {
+					condition.Transition = timestamp
+					condition.Message = message
+				}
 				condition.Status = true
-				condition.Transition = timestamp
 				condition.Reason = rule.Reason
-				condition.Message = message
 				break
 			}
 		}


### PR DESCRIPTION
Previously, we update transition timestamp whenever a new problem is matched from the log.
However, the kernel problem sometimes shows up for multiple even infinity times, for example the hung task problem. This will cause a lot of unnecessary condition updates.

This PR changes kernel monitor to only update the transition timestamp and message when problem status or reason is changed. This makes sure that we only update condition when it actually changes.

This change is also for scalability (Ref https://github.com/kubernetes/node-problem-detector/issues/58)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/84)
<!-- Reviewable:end -->
