### PR TITLE
change long option prefix to short option prefix

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -20,4 +20,4 @@ RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC
 
 ADD ./bin/node-problem-detector /node-problem-detector
 ADD config /config
-ENTRYPOINT ["/node-problem-detector", "--kernel-monitor=/config/kernel-monitor.json"]
+ENTRYPOINT ["/node-problem-detector", "-kernel-monitor=/config/kernel-monitor.json"]

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -12,8 +12,8 @@ spec:
       - name: node-problem-detector
         command:
         - /node-problem-detector
-        - --logtostderr
-        - --kernel-monitor=/config/kernel-monitor.json
+        - -logtostderr
+        - -kernel-monitor=/config/kernel-monitor.json
         image: gcr.io/google_containers/node-problem-detector:v0.2
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
This PR change long command line option prefix to short command line option prefix. I.e., `--` -> `-`.

@Random-Liu PTAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/87)
<!-- Reviewable:end -->
