### PR TITLE
fix npd binary generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 # Build the node-problem-detector image.
 
-.PHONY: all build-container build-tar build push-container push-tar push clean vet fmt version Dockerfile
+.PHONY: all build-container build-tar build push-container push-tar push clean vet fmt version Dockerfile node_problem_detector
 
 all: build
 
@@ -78,7 +78,7 @@ fmt:
 version:
 	@echo $(VERSION)
 
-./bin/node-problem-detector: $(PKG_SOURCES)
+node-problem-detector: $(PKG_SOURCES)
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux go build -o bin/node-problem-detector \
 	     -ldflags '-w -X $(PKG)/pkg/version.version=$(VERSION)' \
 	     $(BUILD_TAGS) cmd/node_problem_detector.go
@@ -89,10 +89,10 @@ Dockerfile: Dockerfile.in
 test: vet fmt
 	go test -timeout=1m -v -race ./pkg/... $(BUILD_TAGS)
 
-build-container: ./bin/node-problem-detector Dockerfile
+build-container: node-problem-detector Dockerfile
 	docker build -t $(IMAGE) .
 
-build-tar: ./bin/node-problem-detector
+build-tar: node-problem-detector
 	tar -zcvf $(TARBALL) bin/ config/
 	sha1sum $(TARBALL)
 	md5sum $(TARBALL)


### PR DESCRIPTION
This PR fix [#39(discussion1)](https://github.com/kubernetes/node-problem-detector/pull/39#discussion_r89067352), [#39(discussion2)](https://github.com/kubernetes/node-problem-detector/pull/39#discussion_r99326431).

Way to repreduce(adjusted from [#39(discussion1)](https://github.com/kubernetes/node-problem-detector/pull/39#discussion_r89067352))

```
make
# The ./bin/node-problem-detector file didn't exist and make created it.
# systemd-journal is enabled.
make ENABLE_JOURNALD=0
# The ./bin/node-problem-detector file already exists and make skipped the ./bin/node-problem-detector target. 
# However the user believes that node-problem-detector is compiled with systemd-journal disabled.
```

/cc @dchen1107 @jfilak @kubernetes/node-problem-detector-reviewers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/89)
<!-- Reviewable:end -->
