### PR TITLE
change flag to pflag

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -20,4 +20,4 @@ RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC
 
 ADD ./bin/node-problem-detector /node-problem-detector
 ADD config /config
-ENTRYPOINT ["/node-problem-detector", "-kernel-monitor=/config/kernel-monitor.json"]
+ENTRYPOINT ["/node-problem-detector", "--kernel-monitor=/config/kernel-monitor.json"]

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ List of supported problem daemons:
 
 # Usage
 ## Flags
-* `-version`: Print current version of node-problem-detector.
-* `-kernel-monitor`: The configuration used by the kernel monitor, e.g.
+* `--version`: Print current version of node-problem-detector.
+* `--kernel-monitor`: The configuration used by the kernel monitor, e.g.
   [config/kernel-monitor.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json).
-* `-apiserver-override`: A URI parameter used to customize how node-problem-detector
+* `--apiserver-override`: A URI parameter used to customize how node-problem-detector
 connects the apiserver. The format is same as the
 [`source`](https://github.com/kubernetes/heapster/blob/master/docs/source-configuration.md#kubernetes)
 flag of [Heapster](https://github.com/kubernetes/heapster).
@@ -65,7 +65,7 @@ For example, to run without auth, use the following config:
 http://APISERVER_IP:APISERVER_PORT?inClusterConfig=false
 ```
 Refer [heapster docs](https://github.com/kubernetes/heapster/blob/1e40b0f4b5eeb3f02e11ee22c2b6fda36b6e6ea1/docs/source-configuration.md#kubernetes) for a complete list of available options.
-* `-hostname-override`: A customized node name used for node-problem-detector to update conditions and emit events. node-problem-detector gets node name first from `hostname-override`, then `NODE_NAME` environment variable and finally fall back to `os.Hostname`.
+* `--hostname-override`: A customized node name used for node-problem-detector to update conditions and emit events. node-problem-detector gets node name first from `hostname-override`, then `NODE_NAME` environment variable and finally fall back to `os.Hostname`.
 
 ## Build Image
 Run `make` in the top directory. It will:
@@ -123,7 +123,7 @@ teach node-problem-detector how to access apiserver with `apiserver-override`.
 
 To run node-problem-detector standalone with an insecure apiserver connection:
 ```
-node-problem-detector -apiserver-override=http://APISERVER_IP:APISERVER_INSECURE_PORT?inClusterConfig=false
+node-problem-detector --apiserver-override=http://APISERVER_IP:APISERVER_INSECURE_PORT?inClusterConfig=false
 ```
 
 For more scenarios, see [here](https://github.com/kubernetes/heapster/blob/master/docs/source-configuration.md#kubernetes)

--- a/cmd/node_problem_detector.go
+++ b/cmd/node_problem_detector.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 
 	"github.com/golang/glog"
+	"github.com/spf13/pflag"
 
 	"k8s.io/node-problem-detector/pkg/kernelmonitor"
 	"k8s.io/node-problem-detector/pkg/problemdetector"
@@ -34,12 +35,12 @@ import (
 
 // TODO: Move flags to options directory.
 var (
-	kernelMonitorConfigPath = flag.String("kernel-monitor", "/config/kernel-monitor.json", "The path to the kernel monitor config file")
-	apiServerOverride       = flag.String("apiserver-override", "", "Custom URI used to connect to Kubernetes ApiServer")
-	printVersion            = flag.Bool("version", false, "Print version information and quit")
-	hostnameOverride        = flag.String("hostname-override", "", "Custom node name used to override hostname")
-	serverPort              = flag.Int("port", 10256, "The port to bind the node problem detector server. Use 0 to disable.")
-	serverAddress           = flag.String("address", "127.0.0.1", "The address to bind the node problem detector server.")
+	kernelMonitorConfigPath = pflag.String("kernel-monitor", "/config/kernel-monitor.json", "The path to the kernel monitor config file")
+	apiServerOverride       = pflag.String("apiserver-override", "", "Custom URI used to connect to Kubernetes ApiServer")
+	printVersion            = pflag.Bool("version", false, "Print version information and quit")
+	hostnameOverride        = pflag.String("hostname-override", "", "Custom node name used to override hostname")
+	serverPort              = pflag.Int("port", 10256, "The port to bind the node problem detector server. Use 0 to disable.")
+	serverAddress           = pflag.String("address", "127.0.0.1", "The address to bind the node problem detector server.")
 )
 
 func validateCmdParams() {
@@ -94,7 +95,9 @@ func startHTTPServer(p problemdetector.ProblemDetector) {
 }
 
 func main() {
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
 	validateCmdParams()
 
 	if *printVersion {

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -12,8 +12,8 @@ spec:
       - name: node-problem-detector
         command:
         - /node-problem-detector
-        - -logtostderr
-        - -kernel-monitor=/config/kernel-monitor.json
+        - --logtostderr
+        - --kernel-monitor=/config/kernel-monitor.json
         image: gcr.io/google_containers/node-problem-detector:v0.2
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
This PR is followed by #87 .

This PR will replace `flag` package with `spf13/pflag`. The output of `./bin/node-problem-detector -h` will like below:
```
Usage of ./bin/node-problem-detector:
      --address="127.0.0.1": The address to bind the node problem detector server.
      --alsologtostderr[=false]: log to standard error as well as files
      --apiserver-override="": Custom URI used to connect to Kubernetes ApiServer
      --hostname-override="": Custom node name used to override hostname
      --kernel-monitor="/config/kernel-monitor.json": The path to the kernel monitor config file
      --log_backtrace_at=:0: when logging hits line file:N, emit a stack trace
      --log_dir="": If non-empty, write log files in this directory
      --logtostderr[=false]: log to standard error instead of files
      --port=10256: The port to bind the node problem detector server. Use 0 to disable.
      --stderrthreshold=2: logs at or above this threshold go to stderr
      --v=0: log level for V logs
      --version[=false]: Print version information and quit
      --vmodule=: comma-separated list of pattern=N settings for file-filtered logging
```

At the same time, this PR also changes command line argument usage info in docs and configuration. :)

/cc @dchen1107 @kubernetes/node-problem-detector-reviewers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/90)
<!-- Reviewable:end -->
