### PR TITLE
Create a goroutine for the http server.

### DIFF
--- a/cmd/node_problem_detector.go
+++ b/cmd/node_problem_detector.go
@@ -44,10 +44,12 @@ func startHTTPServer(p problemdetector.ProblemDetector, npdo *options.NodeProble
 	p.RegisterHTTPHandlers()
 
 	addr := net.JoinHostPort(npdo.ServerAddress, strconv.Itoa(npdo.ServerPort))
-	err := http.ListenAndServe(addr, nil)
-	if err != nil {
-		glog.Fatalf("Failed to start server: %v", err)
-	}
+	go func() {
+		err := http.ListenAndServe(addr, nil)
+		if err != nil {
+			glog.Fatalf("Failed to start server: %v", err)
+		}
+	}()
 }
 
 func main() {


### PR DESCRIPTION
The original goroutine is removed by mistake when addressing comments in https://github.com/kubernetes/node-problem-detector/pull/83.

An e2e test is really needed now. :(

@andyxning Could you help me review this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/93)
<!-- Reviewable:end -->
