### PR TITLE
Add multiple system log monitor support

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -20,4 +20,4 @@ RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC
 
 ADD ./bin/node-problem-detector /node-problem-detector
 ADD config /config
-ENTRYPOINT ["/node-problem-detector", "--system-log-monitor=/config/kernel-monitor.json"]
+ENTRYPOINT ["/node-problem-detector", "--system-log-monitors=/config/kernel-monitor.json"]

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ List of supported problem daemons:
 # Usage
 ## Flags
 * `--version`: Print current version of node-problem-detector.
-* `--system-log-monitor`: The configuration used by the system log monitor, e.g.
+* `--system-log-monitors`: List of paths to system log monitor configuration files, comma separated, e.g.
   [config/kernel-monitor.json](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json).
+  Node problem detector will start a separate log monitor for each configuration. You can
+  use different log monitors to monitor different system log.
 * `--apiserver-override`: A URI parameter used to customize how node-problem-detector
 connects the apiserver. The format is same as the
 [`source`](https://github.com/kubernetes/heapster/blob/master/docs/source-configuration.md#kubernetes)

--- a/cmd/node_problem_detector.go
+++ b/cmd/node_problem_detector.go
@@ -67,9 +67,17 @@ func main() {
 		os.Exit(0)
 	}
 
-	l := systemlogmonitor.NewLogMonitorOrDie(npdo.SystemLogMonitorConfigPath)
+	monitors := make(map[string]systemlogmonitor.LogMonitor)
+	for _, config := range npdo.SystemLogMonitorConfigPaths {
+		if _, ok := monitors[config]; ok {
+			// Skip the config if it's duplictaed.
+			glog.Warningf("Duplicated log monitor configuration %q", config)
+			continue
+		}
+		monitors[config] = systemlogmonitor.NewLogMonitorOrDie(config)
+	}
 	c := problemclient.NewClientOrDie(npdo)
-	p := problemdetector.NewProblemDetector(l, c)
+	p := problemdetector.NewProblemDetector(monitors, c)
 
 	// Start http server.
 	if npdo.ServerPort > 0 {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -30,8 +30,9 @@ import (
 type NodeProblemDetectorOptions struct {
 	// command line options
 
-	// SystemLogMonitorConfigPath specifies the path to system log monitor configuration file.
-	SystemLogMonitorConfigPath string
+	// SystemLogMonitorConfigPaths specifies the list of paths to system log monitor configuration
+	// files.
+	SystemLogMonitorConfigPaths []string
 	// ApiServerOverride is the custom URI used to connect to Kubernetes ApiServer.
 	ApiServerOverride string
 	// PrintVersion is the flag determining whether version information is printed.
@@ -55,8 +56,8 @@ func NewNodeProblemDetectorOptions() *NodeProblemDetectorOptions {
 
 // AddFlags adds node problem detector command line options to pflag.
 func (npdo *NodeProblemDetectorOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&npdo.SystemLogMonitorConfigPath, "system-log-monitor",
-		"/config/kernel-monitor.json", "The path to the system log monitor config file")
+	fs.StringSliceVar(&npdo.SystemLogMonitorConfigPaths, "system-log-monitors",
+		[]string{}, "List of paths to system log monitor config files, comma separated.")
 	fs.StringVar(&npdo.ApiServerOverride, "apiserver-override",
 		"", "Custom URI used to connect to Kubernetes ApiServer")
 	fs.BoolVar(&npdo.PrintVersion, "version", false, "Print version information and quit")

--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_test.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_test.go
@@ -19,6 +19,7 @@ package filelog
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -169,4 +170,17 @@ Jan  2 03:04:05 kernel: [2.000000] 3
 		case <-timeout:
 		}
 	}
+}
+
+func TestGoroutineLeak(t *testing.T) {
+	orignal := runtime.NumGoroutine()
+	w := NewSyslogWatcherOrDie(types.WatcherConfig{
+		Plugin:       "filelog",
+		PluginConfig: getTestPluginConfig(),
+		LogPath:      "/not/exist/path",
+		Lookback:     "10m",
+	})
+	_, err := w.Watch()
+	assert.Error(t, err)
+	assert.Equal(t, orignal, runtime.NumGoroutine())
 }

--- a/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
@@ -20,6 +20,7 @@ package journald
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -133,6 +134,11 @@ func getJournal(cfg types.WatcherConfig) (*sdjournal.Journal, error) {
 	since, err := time.ParseDuration(cfg.Lookback)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse lookback duration %q: %v", cfg.Lookback, err)
+	}
+	// If the path doesn't present, NewJournalFromDir will create it instead of
+	// returning error. So check the path existence ourselves.
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("failed to stat the log path %q: %v", path, err)
 	}
 	// Get journal client from the log path.
 	journal, err := sdjournal.NewJournalFromDir(path)

--- a/pkg/systemlogmonitor/logwatchers/testing/fake_log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/testing/fake_log_watcher.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"sync"
+
+	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
+	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
+)
+
+// FakeLogWatcher is a fake mock of log watcher.
+type FakeLogWatcher struct {
+	sync.Mutex
+	buf chan *logtypes.Log
+	err error
+}
+
+var _ types.LogWatcher = &FakeLogWatcher{}
+
+func NewFakeLogWatcher(bufferSize int) *FakeLogWatcher {
+	return &FakeLogWatcher{buf: make(chan *logtypes.Log, bufferSize)}
+}
+
+// InjectLog injects a fake log into the watch channel
+func (f *FakeLogWatcher) InjectLog(log *logtypes.Log) {
+	f.buf <- log
+}
+
+// InjectError injects an error of Watch function.
+func (f *FakeLogWatcher) InjectError(err error) {
+	f.Lock()
+	defer f.Unlock()
+	f.err = err
+}
+
+// Watch is the fake watch function.
+func (f *FakeLogWatcher) Watch() (<-chan *logtypes.Log, error) {
+	return f.buf, f.err
+}
+
+// Stop is the fake stop function.
+func (f *FakeLogWatcher) Stop() {
+	close(f.buf)
+}


### PR DESCRIPTION
For #44.
Based on #81, #88 and #92.

Only the last commit is new.

This PR change the `--log-monitor` flag to `--log-monitors`. Multiple log monitor config separated by comma can be passed through `--log-monitors`, NPD will start a separate log monitor for each of them.

This makes it possible to use NPD to monitor different system log at the same time.

/cc @dchen1107 @kubernetes/node-problem-detector-reviewers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/94)
<!-- Reviewable:end -->
