### PR TITLE
fix misspell "timestamp"

### DIFF
--- a/pkg/systemlogmonitor/logwatchers/filelog/translator.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/translator.go
@@ -66,7 +66,7 @@ func (t *translator) translate(line string) (*logtypes.Log, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse timestamp %q: %v", matches[len(matches)-1], err)
 	}
-	// Formalize the timestmap.
+	// Formalize the timestamp.
 	timestamp = formalizeTimestamp(timestamp)
 	// Parse message.
 	matches = t.messageRegexp.FindStringSubmatch(line)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/95)
<!-- Reviewable:end -->
