### PR TITLE
Add ABRT adaptor config

### DIFF
--- a/config/abrt-adaptor.json
+++ b/config/abrt-adaptor.json
@@ -1,0 +1,38 @@
+{
+	"plugin": "journald",
+	"pluginConfig": {
+		"source": "abrt-notification"
+	},
+	"logPath": "/var/log/journal",
+	"lookback": "5m",
+	"bufferSize": 10,
+	"source": "abrt-adaptor",
+	"conditions": [],
+	"rules": [
+		{
+			"type": "temporary",
+			"reason": "CCPPCrash",
+			"pattern": "Process \\d+ \\(\\S+\\) crashed in \\S+"
+		},
+		{
+			"type": "temporary",
+			"reason": "UncaughtException",
+			"pattern": "Process \\d+ \\(\\S+\\) of user \\d+ encountered an uncaught \\S+ exception"
+		},
+		{
+			"type": "temporary",
+			"reason": "XorgCrash",
+			"pattern": "Display server \\S+ crash in \\S+"
+		},
+		{
+			"type": "temporary",
+			"reason": "VMcore",
+			"pattern": "System encountered a fatal error in \\S+"
+		},
+		{
+			"type": "temporary",
+			"reason": "Kerneloops",
+			"pattern": "System encountered a non-fatal error in \\S+"
+		}
+	]
+}


### PR DESCRIPTION
This config allows NPD to catch problems detected by ABRT, ABRT can find various problems (see the link) and log them to journalctl in format described here:
https://github.com/abrt/abrt/wiki/systemd-journal-catalog-messages

Work sequence:
1. ABRT processes problem and logs to journal
2. NDP catches ABRT logs and report them to upper layer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/105)
<!-- Reviewable:end -->
