### PR TITLE
Abrt readme and ccpp fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ List of supported problem daemons:
 | Problem Daemon |  NodeCondition  | Description |
 |----------------|:---------------:|:------------|
 | [KernelMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) | KernelDeadlock | A system log monitor monitors kernel log and reports problem according to predefined rules. |
+| [AbrtAdaptor](https://github.com/kubernetes/node-problem-detector/blob/master/config/abrt-adaptor.json) | None | Monitor ABRT log messages and report them further. ABRT (Automatic Bug Report Tool) is health monitoring daemon able to catch kernel problems as well as application crashes of various kinds occured on the host. For more information visit the [link](https://github.com/abrt). |
 
 # Usage
 ## Flags

--- a/config/abrt-adaptor.json
+++ b/config/abrt-adaptor.json
@@ -12,7 +12,7 @@
 		{
 			"type": "temporary",
 			"reason": "CCPPCrash",
-			"pattern": "Process \\d+ \\(\\S+\\) crashed in \\S+"
+			"pattern": "Process \\d+ \\(\\S+\\) crashed in .*"
 		},
 		{
 			"type": "temporary",


### PR DESCRIPTION
This PR contains 2 changes.

* First is README update, that contains documented use of ABRT by NPD, my leader asked me to do.
* Second is abrt-adaptor ccpp pattern fix, I found it didn't catch all possible cpp problem messages produced by ABRT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/111)
<!-- Reviewable:end -->
