### PR TITLE
Add rule for docker image pull error

### DIFF
--- a/config/docker-monitor-filelog.json
+++ b/config/docker-monitor-filelog.json
@@ -10,5 +10,11 @@
 	"bufferSize": 10,
 	"source": "docker-monitor",
 	"conditions": [],
-	"rules": []
+	"rules": [
+		{
+			"type": "temporary",
+			"reason": "CorruptDockerImage",
+			"pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
+		}
+	]
 }

--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -8,5 +8,11 @@
 	"bufferSize": 10,
 	"source": "docker-monitor",
 	"conditions": [],
-	"rules": []
+	"rules": [
+		{
+			"type": "temporary",
+			"reason": "CorruptDockerImage",
+			"pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
+		}
+	]
 }


### PR DESCRIPTION
Add a new rule which catches docker image corruption. It will address https://github.com/kubernetes/kubernetes/issues/47219

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/117)
<!-- Reviewable:end -->
