### PR TITLE
Split Test and Build in Different Stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
  - mkdir -p $HOME/gopath/src/k8s.io
  - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/node-problem-detector
  - cd $HOME/gopath/src/k8s.io/node-problem-detector
-script:
- - make test
- - make
+jobs:
+  include:
+    - stage: Test
+      script: make test
+    - stage: Build
+      script: make


### PR DESCRIPTION
Split UT and Build Stages in different jobs of travis CI so that it's easy for user to traces what went wrong in CI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/132)
<!-- Reviewable:end -->
