### PR TITLE
given the daemonset a name in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ metadata:
   name: node-problem-detector
 spec:
   template:
+    metadata:
+      labels:
+        name: nodeProblemDetector
     spec:
       containers:
       - name: node-problem-detector


### PR DESCRIPTION
otherwise, `kubectl create -f` was complaining with

```
The DaemonSet "node-problem-detector" is invalid: spec.template.metadata.labels: Invalid value: map[string]string(nil): `selector` does not match template `labels`
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/133)
<!-- Reviewable:end -->
