### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Refer [heapster docs](https://github.com/kubernetes/heapster/blob/master/docs/so
 Run `make` in the top directory. It will:
 * Build the binary.
 * Build the docker image. The binary and `config/` are copied into the docker image.
-* Upload the docker image to registry. By default, the image will be uploaded to
+
+## Push Image
+`make push` uploads the docker image to registry. By default, the image will be uploaded to
 `gcr.io/google_containers`. It's easy to modify the `Makefile` to push the image
-to another registry
+to another registry.
 
 ## Start DaemonSet
 * Create a file node-problem-detector.yaml with the following yaml.


### PR DESCRIPTION
update description about `Build Image`. When running `make`, it will
not push image to registry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/139)
<!-- Reviewable:end -->
