### PR TITLE
update golang to 1.8 and 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: required
 dist: trusty
 language: go
 go:
- - 1.6
- - 1.7
+ - 1.8
+ - 1.9
 services:
  - docker
 before_install:


### PR DESCRIPTION
This PR will update travisCI golang version from `1.6` and `1.7` to `1.8` and `1.9`. Since golang `1.9` has been released for a while.

/cc @Random-Liu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/140)
<!-- Reviewable:end -->
