### PR TITLE
add setup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,20 @@ Refer [heapster docs](https://github.com/kubernetes/heapster/blob/master/docs/so
 * `--hostname-override`: A customized node name used for node-problem-detector to update conditions and emit events. node-problem-detector gets node name first from `hostname-override`, then `NODE_NAME` environment variable and finally fall back to `os.Hostname`.
 
 ## Build Image
-Run `make` in the top directory. It will:
-* Build the binary.
-* Build the docker image. The binary and `config/` are copied into the docker image.
+* `go get` or `git clone` node-problem-detector repo into `$GOPATH/src/k8s.io` or `$GOROOT/src/k8s.io` 
+with one of the below directions:
+  * `cd $GOPATH/src/k8s.io && git clone git@github.com:kubernetes/node-problem-detector.git`
+  * `cd $GOROOT/src/k8s.io && git clone git@github.com:kubernetes/node-problem-detector.git`
+  * `cd $GOPATH/src/k8s.io && go get k8s.io/node-problem-detector`
+
+* run `make` in the top directory. It will:
+  * Build the binary.
+  * Build the docker image. The binary and `config/` are copied into the docker image.
+
+**Note**:
+By default node-problem-detector will be built with systemd support with `make` command. This requires systemd develop files. 
+You should download the systemd develop files first. For Ubuntu, `libsystemd-journal-dev` package should 
+be installed.
 
 ## Push Image
 `make push` uploads the docker image to registry. By default, the image will be uploaded to


### PR DESCRIPTION
partially fix #142 

This PR adds description about how to get the node-problem-detector repo and systemd build dependency.

Note: This PR should be merged only after [k8s.io #85](https://github.com/kubernetes/k8s.io/pull/85) is merged as description in this PR has `go get k8s.io/node-problem-detector` which is only valid after [k8s.io #85](https://github.com/kubernetes/k8s.io/pull/85) has been merged.
@Spellchaser

/cc @Random-Liu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/144)
<!-- Reviewable:end -->
