### PR TITLE
Update Docker Image tag reference to v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ spec:
     spec:
       containers:
       - name: node-problem-detector
-        image: gcr.io/google_containers/node-problem-detector:v0.2
+        image: gcr.io/google_containers/node-problem-detector:v0.4.1
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/node-problem-detector.yaml
+++ b/node-problem-detector.yaml
@@ -14,7 +14,7 @@ spec:
         - /node-problem-detector
         - --logtostderr
         - --kernel-monitor=/config/kernel-monitor.json
-        image: gcr.io/google_containers/node-problem-detector:v0.2
+        image: gcr.io/google_containers/node-problem-detector:v0.4.1
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
Upgrade references to the node-problem-detector Docker Image to latest available version on gcr.io v0.4.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/148)
<!-- Reviewable:end -->
