### PR TITLE
Changed unknown status echo to exit in network_problem custom plugin

### DIFF
--- a/config/plugin/network_problem.sh
+++ b/config/plugin/network_problem.sh
@@ -7,8 +7,8 @@ OK=0
 NONOK=1
 UNKNOWN=2
 
-[ -f /proc/sys/net/ipv4/netfilter/ip_conntrack_max ] || echo $UNKNOWN
-[ -f /proc/sys/net/ipv4/netfilter/ip_conntrack_count ] || echo $UNKNOWN
+[ -f /proc/sys/net/ipv4/netfilter/ip_conntrack_max ] || exit $UNKNOWN
+[ -f /proc/sys/net/ipv4/netfilter/ip_conntrack_count ] || exit $UNKNOWN
 
 conntrack_max=$(cat /proc/sys/net/ipv4/netfilter/ip_conntrack_max)
 conntrack_count=$(cat /proc/sys/net/ipv4/netfilter/ip_conntrack_count)


### PR DESCRIPTION
My comment was eaten by github in #152 and wanted to raise attention incase this was meant to be an exit instead of an echo, otherwise feel free to close!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/155)
<!-- Reviewable:end -->
