### PR TITLE
Use camelCase instead of snake_case per Golang convention

### DIFF
--- a/pkg/custompluginmonitor/types/config.go
+++ b/pkg/custompluginmonitor/types/config.go
@@ -82,12 +82,12 @@ func (cpc *CustomPluginConfig) ApplyConfiguration() error {
 		cpc.PluginGlobalConfig.InvokeIntervalString = &defaultInvokeIntervalString
 	}
 
-	invoke_interval, err := time.ParseDuration(*cpc.PluginGlobalConfig.InvokeIntervalString)
+	invokeInterval, err := time.ParseDuration(*cpc.PluginGlobalConfig.InvokeIntervalString)
 	if err != nil {
 		return fmt.Errorf("error in parsing invoke interval %q: %v", *cpc.PluginGlobalConfig.InvokeIntervalString, err)
 	}
 
-	cpc.PluginGlobalConfig.InvokeInterval = &invoke_interval
+	cpc.PluginGlobalConfig.InvokeInterval = &invokeInterval
 
 	if cpc.PluginGlobalConfig.MaxOutputLength == nil {
 		cpc.PluginGlobalConfig.MaxOutputLength = &defaultMaxOutputLength


### PR DESCRIPTION
Use camelCase instead of snake_case per Golang convention.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/158)
<!-- Reviewable:end -->
