### PR TITLE
Fix doc links for ConfigMap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ spec:
 ```
 * Edit node-problem-detector.yaml to fit your environment: Set `log` volume to your system log directory. (Used by SystemLogMonitor)
 * Create the DaemonSet with `kubectl create -f node-problem-detector.yaml`
-* If needed, you can use [ConfigMap](http://kubernetes.io/docs/user-guide/configmap/)
+* If needed, you can use [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
 to overwrite the `config/`.
 
 ## Start Standalone


### PR DESCRIPTION
This link seems to have been updated.
Signed-off-by: renchao <renchao@chinacloud.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/159)
<!-- Reviewable:end -->
