### PR TITLE
Use debian-base image from kubernetes repository as base for NPD.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,17 @@ IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
 ENABLE_JOURNALD?=1
 
 # TODO(random-liu): Support different architectures.
-BASEIMAGE:=alpine:3.4
+# The debian-base:0.3 image built from kubernetes repository is based on Debian Stretch.
+# It includes systemd 232 with support for both +XZ and +LZ4 compression.
+# +LZ4 is needed on some os distros such as COS.
+BASEIMAGE:=gcr.io/google-containers/debian-base-amd64:0.3
 
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0
 
-# NOTE that enable journald will increase the image size.
 ifeq ($(ENABLE_JOURNALD), 1)
 	# Enable journald build tag.
 	BUILD_TAGS:=-tags journald
-	# Use fedora because it has newer systemd version (229) and support +LZ4. +LZ4 is needed
-	# on some os distros such as GCI.
-	BASEIMAGE:=fedora
 	# Enable cgo because sdjournal needs cgo to compile. The binary will be dynamically
 	# linked if CGO_ENABLED is enabled. This is fine because fedora already has necessary
 	# dynamic library. We can not use `-extldflags "-static"` here, because go-systemd uses


### PR DESCRIPTION
This image is based on Debian Stretch (9) which has a recent version of systemd libraries that includes all necessary compression algorithms.

I propose using that image unconditionally (instead of Alpine when journald is disabled) since the image size with debian-base is not that much of a concern anymore.

FTR, I didn't really test this...

This is analogous to a change we're pushing to fluentd-gcp container in GoogleCloudPlatform/k8s-stackdriver#101

@Random-Liu 

Cheers,
Filipe

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/160)
<!-- Reviewable:end -->
