### PR TITLE
Unit testing for SetNodeNameOrDie in package cmd/options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ Dockerfile: Dockerfile.in
 	sed -e 's|@BASEIMAGE@|$(BASEIMAGE)|g' $< >$@
 
 test: vet fmt
-	go test -timeout=1m -v -race ./pkg/... $(BUILD_TAGS)
+	go test -timeout=1m -v -race ./cmd/options ./pkg/... $(BUILD_TAGS)
 
 build-container: ./bin/node-problem-detector Dockerfile
 	docker build -t $(IMAGE) .

--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package options
 
 import (
@@ -13,7 +29,7 @@ type Options struct {
 	HostnameOverride string
 }
 
-//TestSetNodeNameOrDie tests for permutations of nodename, hostname and hostnameoverride
+// TestSetNodeNameOrDie tests for permutations of nodename, hostname and hostnameoverride
 func TestSetNodeNameOrDie(t *testing.T) {
 	options := map[string]struct {
 		Expected         Options
@@ -88,11 +104,11 @@ func TestSetNodeNameOrDie(t *testing.T) {
 		}
 
 		if opt.Expected.Hostname != "" {
-			//Changing hostname
+			// Changing hostname
 			cmd := exec.Command("hostname", opt.Expected.Hostname)
 			_, err := cmd.CombinedOutput()
 			if err != nil {
-				//If changing hostname requires admin privilege
+				// If changing hostname requires admin privilege
 				cmd = exec.Command("sudo", "hostname", opt.Expected.Hostname)
 				_, err := cmd.CombinedOutput()
 				if err != nil {
@@ -120,7 +136,7 @@ func TestSetNodeNameOrDie(t *testing.T) {
 		}
 
 	}
-
+	// Setting back the original attributes
 	err = os.Setenv("NODE_NAME", orig_node_name)
 	if err != nil {
 		fmt.Println("Unable to set original : env NODE_NAME")

--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -26,7 +26,7 @@ type options struct {
 	HostnameOverride string
 }
 
-// TestSetNodeNameOrDie tests for permutations of nodename, hostname and hostnameoverride
+// TestSetNodeNameOrDie tests for permutations of nodename, hostname and hostnameoverride.
 func TestSetNodeNameOrDie(t *testing.T) {
 	option := map[string]struct {
 		Expected         options
@@ -67,7 +67,7 @@ func TestSetNodeNameOrDie(t *testing.T) {
 
 	for str, opt := range option {
 
-		// Setting with expected(desired) NODE_NAME env
+		// Setting with expected(desired) NODE_NAME env.
 		err = os.Setenv("NODE_NAME", opt.Expected.Nodename)
 		if err != nil {
 			t.Errorf("Unable to set env NODE_NAME")
@@ -75,19 +75,19 @@ func TestSetNodeNameOrDie(t *testing.T) {
 
 		npdObj := NewNodeProblemDetectorOptions()
 
-		// Setting with expected(desired) HostnameOverride
+		// Setting with expected(desired) HostnameOverride.
 		npdObj.HostnameOverride = opt.Expected.HostnameOverride
 
 		npdObj.SetNodeNameOrDie()
 		opt.ObtainedNodeName = npdObj.NodeName
 
-		// Setting back the original node name
+		// Setting back the original node name.
 		err = os.Setenv("NODE_NAME", orig_node_name)
 		if err != nil {
 			t.Errorf("Unable to set original : env NODE_NAME")
 		}
 
-		// Checking for obtained node name
+		// Checking for obtained node name.
 		if opt.ObtainedNodeName != opt.Expected.HostnameOverride &&
 			opt.ObtainedNodeName != opt.Expected.Nodename &&
 			opt.ObtainedNodeName != orig_host_name {

--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -1,0 +1,134 @@
+package options
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+type Options struct {
+	Nodename         string
+	Hostname         string
+	HostnameOverride string
+}
+
+//TestSetNodeNameOrDie tests for permutations of nodename, hostname and hostnameoverride
+func TestSetNodeNameOrDie(t *testing.T) {
+	options := map[string]struct {
+		Expected         Options
+		ObtainedNodeName string
+	}{
+		"Check Node and HostnameOverride only": {
+			Expected: Options{
+				Nodename:         "my-node-name",
+				Hostname:         "",
+				HostnameOverride: "override",
+			},
+		},
+		"Check Nodename only": {
+			Expected: Options{
+				Nodename:         "my-node-name",
+				Hostname:         "",
+				HostnameOverride: "",
+			},
+		},
+
+		"Check HostnameOverride only": {
+			Expected: Options{
+				Nodename:         "",
+				Hostname:         "",
+				HostnameOverride: "override",
+			},
+		},
+		"Check Hostname only": {
+			Expected: Options{
+				Nodename:         "",
+				Hostname:         "my-host-name",
+				HostnameOverride: "",
+			},
+		},
+		"Check Node, host and HostnameOverride only": {
+			Expected: Options{
+				Nodename:         "my-node-name",
+				Hostname:         "my-host-name",
+				HostnameOverride: "override",
+			},
+		},
+
+		"Check Host and HostnameOverride only": {
+			Expected: Options{
+				Nodename:         "",
+				Hostname:         "my-host-name",
+				HostnameOverride: "override",
+			},
+		},
+
+		"Check Node and hostname": {
+			Expected: Options{
+				Nodename:         "my-node-name",
+				Hostname:         "my-host-name",
+				HostnameOverride: "",
+			},
+		},
+	}
+
+	orig_node_name := os.Getenv("NODE_NAME")
+	orig_host_name, err := os.Hostname()
+	if err != nil {
+		fmt.Println("Unable to get hostname")
+	}
+
+	for str, opt := range options {
+		if opt.Expected.Nodename != "" {
+			err = os.Setenv("NODE_NAME", opt.Expected.Nodename)
+			if err != nil {
+				t.Errorf("Unable to set env NODE_NAME")
+			}
+		}
+
+		if opt.Expected.Hostname != "" {
+			//Changing hostname
+			cmd := exec.Command("hostname", opt.Expected.Hostname)
+			_, err := cmd.CombinedOutput()
+			if err != nil {
+				//If changing hostname requires admin privilege
+				cmd = exec.Command("sudo", "hostname", opt.Expected.Hostname)
+				_, err := cmd.CombinedOutput()
+				if err != nil {
+					fmt.Println("Unable to change hostname")
+					return
+				}
+			}
+		}
+
+		npdObj := NewNodeProblemDetectorOptions()
+		npdObj.HostnameOverride = opt.Expected.HostnameOverride
+		npdObj.SetNodeNameOrDie()
+		opt.ObtainedNodeName = npdObj.NodeName
+
+		if opt.ObtainedNodeName != opt.Expected.HostnameOverride &&
+			opt.ObtainedNodeName != opt.Expected.Nodename &&
+			opt.ObtainedNodeName != opt.Expected.Hostname {
+			t.Errorf("Error at : %+v", str)
+			t.Errorf("Wanted: %+v. \nGot: %+v", opt.Expected.Nodename, opt.ObtainedNodeName)
+		}
+
+		err = os.Setenv("NODE_NAME", "")
+		if err != nil {
+			t.Errorf("Unable to set env NODE_NAME empty")
+		}
+
+	}
+
+	err = os.Setenv("NODE_NAME", orig_node_name)
+	if err != nil {
+		fmt.Println("Unable to set original : env NODE_NAME")
+	}
+	cmd := exec.Command("sudo", "hostname", orig_host_name)
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("Unable to set hostname")
+	}
+
+}


### PR DESCRIPTION
1. Why is this change necessary ?
fixes: kubernetes/node-problem-detector#161

2. How does this change address the issue ?
Under package cmd/options, the testing for SetNodeNameOrDie need
to decide Nodename based on environment variable "NODE_NAME" or
hostname or hostnameoverride variable.

3. How to verify this change ?
Run "go test" with admin privilege i.e., "make test"

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/node-problem-detector/162)
<!-- Reviewable:end -->
