### PR TITLE
fix typo in daemonset labelSelector

### DIFF
--- a/deployment/node-problem-detector.yaml
+++ b/deployment/node-problem-detector.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      name: node-problem-detector
+      app: node-problem-detector
   template:
     metadata:
       labels:


### PR DESCRIPTION
The label on the pod is `app: node-problem-detector` while the
label in the `labelSelector` was `name: node-problem-detector`.
This CL updates the `labelSelector` to use `app` rather than `name`.