### PR TITLE
adjust client-go User-Agent

### DIFF
--- a/pkg/problemclient/problem_client.go
+++ b/pkg/problemclient/problem_client.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
@@ -30,6 +32,7 @@ import (
 
 	"k8s.io/heapster/common/kubernetes"
 	"k8s.io/node-problem-detector/cmd/options"
+	"k8s.io/node-problem-detector/pkg/version"
 )
 
 // Client is the interface of problem client
@@ -62,6 +65,7 @@ func NewClientOrDie(npdo *options.NodeProblemDetectorOptions) Client {
 		panic(err)
 	}
 
+	cfg.UserAgent = fmt.Sprintf("%s/%s", filepath.Base(os.Args[0]), version.Version())
 	// TODO(random-liu): Set QPS Limit
 	c.client = client.NewOrDie(cfg)
 	c.nodeName = npdo.NodeName

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,6 +18,10 @@ import "fmt"
 // version defines node-problem-detector version string.
 var version string = "UNKNOWN"
 
+func Version() string {
+	return version
+}
+
 func PrintVersion() {
 	fmt.Println(version)
 }


### PR DESCRIPTION
Fix #181 

This PR will customize client-go, node-problem-detector uses, User-Agent to `node-problem-detector/VERSION`.