### PR TITLE
support go 1.10 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: required
 dist: trusty
 language: go
 go:
- - 1.8
  - 1.9
+ - "1.10"
 services:
  - docker
 before_install:


### PR DESCRIPTION
Since Golang 1.10 has been released for a long time, it should be tested in travis ci. :)

/cc @Random-Liu 