### PR TITLE
Add bash to Dockerfile for custom-plugin-monitors

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -15,6 +15,8 @@
 FROM @BASEIMAGE@
 MAINTAINER Random Liu <lantaol@google.com>
 
+RUN clean-install bash
+
 # Avoid symlink of /etc/localtime.
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true
 


### PR DESCRIPTION
Utilizes the clean-install script from the debian-base image

Fixes #185