### PR TITLE
Adapt OOMKilling pattern to current kernels

### DIFF
--- a/config/kernel-monitor-filelog.json
+++ b/config/kernel-monitor-filelog.json
@@ -20,7 +20,7 @@
 		{
 			"type": "temporary",
 			"reason": "OOMKilling",
-			"pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB"
+			"pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
 		},
 		{
 			"type": "temporary",

--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -18,7 +18,7 @@
 		{
 			"type": "temporary",
 			"reason": "OOMKilling",
-			"pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB"
+			"pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
 		},
 		{
 			"type": "temporary",

--- a/test/kernel_log_generator/problems/oom_kill
+++ b/test/kernel_log_generator/problems/oom_kill
@@ -1,2 +1,2 @@
 Memory cgroup out of memory: Kill process 1012 (heapster) score 1035 or sacrifice child
-Killed process 1012 (heapster) total-vm:327128kB, anon-rss:306328kB, file-rss:11132kB
+Killed process 1012 (heapster) total-vm:327128kB, anon-rss:306328kB, file-rss:11132kB, shmem-rss:12345kB


### PR DESCRIPTION
[commit eca56ff9](https://github.com/torvalds/linux/commit/eca56ff906bdd0239485e8b47154a6e73dd9a2f3#diff-c14acc69885a24f354bc607686800e23) in the Linux Kernel repository added a column for shared memory to the `Killed process` message. As the patterns in the `kernel-monitor(-filelog).json` have to match full lines, they don't match the OOMKilling messages of current Kernels anymore.

This PR fixes this by simply adding a '.*' to the pattern.