### PR TITLE
Enable building the NPD in a docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@
 
 # Build the node-problem-detector image.
 
-.PHONY: all build-container build-tar build push-container push-tar push clean vet fmt version Dockerfile
+.PHONY: all build-container build-tar build push-container push-tar push clean vet fmt version \
+        Dockerfile build-binaries docker-builder build-in-docker
 
 all: build
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
 
 # ENABLE_JOURNALD enables build journald support or not. Building journald support needs libsystemd-dev
 # or libsystemd-journal-dev.
-# TODO(random-liu): Build NPD inside container.
 ENABLE_JOURNALD?=1
 
 # TODO(random-liu): Support different architectures.
@@ -93,7 +92,9 @@ Dockerfile: Dockerfile.in
 test: vet fmt
 	go test -timeout=1m -v -race ./cmd/options ./pkg/... $(BUILD_TAGS)
 
-build-container: ./bin/node-problem-detector ./bin/log-counter Dockerfile
+build-binaries: ./bin/node-problem-detector ./bin/log-counter
+
+build-container: build-binaries Dockerfile
 	docker build -t $(IMAGE) .
 
 build-tar: ./bin/node-problem-detector ./bin/log-counter
@@ -102,6 +103,12 @@ build-tar: ./bin/node-problem-detector ./bin/log-counter
 	md5sum $(TARBALL)
 
 build: build-container build-tar
+
+docker-builder:
+	docker build -t npd-builder ./builder
+
+build-in-docker: clean docker-builder
+	docker run -v `pwd`:/gopath/src/k8s.io/node-problem-detector/ npd-builder:latest bash -c 'cd /gopath/src/k8s.io/node-problem-detector/ && make build-binaries'
 
 push-container: build-container
 	gcloud docker -- push $(IMAGE)

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.10.2
+LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
+
+ENV GOPATH /gopath/
+ENV PATH $GOPATH/bin:$PATH
+
+RUN apt-get update && apt-get --yes install libsystemd-dev
+RUN go version
+RUN go get github.com/tools/godep
+RUN godep version
+CMD ["/bin/bash"]

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM golang:1.11.0
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
+LABEL maintainer="Andy Xie <andy.xning@gmail.com>"
 
 ENV GOPATH /gopath/
 ENV PATH $GOPATH/bin:$PATH

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors. All rights reserved
+# Copyright 2018 The Kubernetes Authors. All rights reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10.2
+FROM golang:1.11.0
 LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
 
 ENV GOPATH /gopath/


### PR DESCRIPTION
This has several benefits. For example, now I can develop and build linux binaries of the NPD on my mac. Also other devs don't need to make sure they have the systemd headers installed.