### PR TITLE
Detect readonly filesystem

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -1,9 +1,6 @@
 {
-	"plugin": "journald",
-	"pluginConfig": {
-		"source": "kernel"
-	},
-	"logPath": "/var/log/journal",
+	"plugin": "kmsg",
+	"logPath": "/dev/kmsg",
 	"lookback": "5m",
 	"bufferSize": 10,
 	"source": "kernel-monitor",
@@ -12,6 +9,11 @@
 			"type": "KernelDeadlock",
 			"reason": "KernelHasNoDeadlock",
 			"message": "kernel has no deadlock"
+		},
+		{
+			"type": "ReadonlyFilesystem",
+			"reason": "FilesystemIsNotReadOnly",
+			"message": "Filesystem is not read-only"
 		}
 	],
 	"rules": [
@@ -51,6 +53,12 @@
 			"condition": "KernelDeadlock",
 			"reason": "DockerHung",
 			"pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
+		},
+		{
+			"type": "permanent",
+			"condition": "ReadonlyFilesystem",
+			"reason": "FilesystemIsReadOnly",
+			"pattern": "Remounting filesystem read-only"
 		}
 	]
 }

--- a/deployment/node-problem-detector-config.yaml
+++ b/deployment/node-problem-detector-config.yaml
@@ -2,11 +2,8 @@ apiVersion: v1
 data:
   kernel-monitor.json: |
     {
-        "plugin": "journald",
-        "pluginConfig": {
-            "source": "kernel"
-        },
-        "logPath": "/var/log/journal",
+        "plugin": "kmsg",
+        "logPath": "/dev/kmsg",
         "lookback": "5m",
         "bufferSize": 10,
         "source": "kernel-monitor",
@@ -15,6 +12,11 @@ data:
                 "type": "KernelDeadlock",
                 "reason": "KernelHasNoDeadlock",
                 "message": "kernel has no deadlock"
+            },
+            {
+                "type": "ReadonlyFilesystem",
+                "reason": "FilesystemIsReadOnly",
+                "message": "Filesystem is read-only"
             }
         ],
         "rules": [
@@ -54,6 +56,12 @@ data:
                 "condition": "KernelDeadlock",
                 "reason": "DockerHung",
                 "pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
+            },
+            {
+                "type": "permanent",
+                "condition": "ReadonlyFilesystem",
+                "reason": "FilesystemIsReadOnly",
+                "pattern": "Remounting filesystem read-only"
             }
         ]
     }

--- a/test/kernel_log_generator/problems/readonly_filesystem
+++ b/test/kernel_log_generator/problems/readonly_filesystem
@@ -1,0 +1,1 @@
+EXT4-fs (sda1): Remounting filesystem read-only


### PR DESCRIPTION
The PR adds one more rule to kernel monitor to detect read-only filesystem. It also changes the plugin from journald to kmsg, because when filessystem becomes readonly, no new logs can be saved into `/var/log`. Then journald does not have new data for problem detection.