### PR TITLE
Detect kubelet and container runtime frequent restarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ ifeq ($(ENABLE_JOURNALD), 1)
 endif
 
 vet:
-	go list ./... | grep -v "./vendor/*" | xargs go vet
+	go list ./... | grep -v "./vendor/*" | xargs go vet $(BUILD_TAGS)
 
 fmt:
 	find . -type f -name "*.go" | grep -v "./vendor/*" | xargs gofmt -s -w -l

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ For example, to test [KernelMonitor](https://github.com/kubernetes/node-problem-
 
 **Note**:
 - You can see more rule examples under [test/kernel_log_generator/problems](https://github.com/kubernetes/node-problem-detector/tree/master/test/kernel_log_generator/problems).
-- For [KernelMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) message injection, all messages should have ```kernel: ``` prefix (also note there is a space after ```:```).
+- For [KernelMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) message injection, all messages should have ```kernel: ``` prefix (also note there is a space after ```:```); or use [generator.sh](https://github.com/kubernetes/node-problem-detector/blob/master/test/kernel_log_generator/generator.sh).
+- To inject other logs into journald like systemd logs, use ```echo 'Some systemd message' | systemd-cat -t systemd```.
 
 # Remedy Systems
 

--- a/cmd/logcounter/log_counter.go
+++ b/cmd/logcounter/log_counter.go
@@ -32,7 +32,7 @@ func main() {
 	fedo.AddFlags(pflag.CommandLine)
 	pflag.Parse()
 
-	counter, err := logcounter.NewKmsgLogCounter(fedo)
+	counter, err := logcounter.NewJournaldLogCounter(fedo)
 	if err != nil {
 		fmt.Print(err)
 		os.Exit(int(types.Unknown))

--- a/cmd/logcounter/options/options.go
+++ b/cmd/logcounter/options/options.go
@@ -29,14 +29,21 @@ func NewLogCounterOptions() *LogCounterOptions {
 // LogCounterOptions contains frequent event detector command line and application options.
 type LogCounterOptions struct {
 	// command line options. See flag descriptions for the description
-	Lookback string
-	Pattern  string
-	Count    int
+	JournaldSource string
+	LogPath        string
+	Lookback       string
+	Delay          string
+	Pattern        string
+	Count          int
 }
 
 // AddFlags adds log counter command line options to pflag.
 func (fedo *LogCounterOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&fedo.JournaldSource, "journald-source", "", "The source configuration of journald, e.g., kernel, kubelet, dockerd, etc")
+	fs.StringVar(&fedo.LogPath, "log-path", "", "The log path that log watcher looks up")
 	fs.StringVar(&fedo.Lookback, "lookback", "", "The time log watcher looks up")
+	fs.StringVar(&fedo.Delay, "delay", "",
+		"The time duration log watcher delays after node boot time. This is useful when log watcher needs to wait for some time until the node is stable.")
 	fs.StringVar(&fedo.Pattern, "pattern", "",
 		"The regular expression to match the problem in log. The pattern must match to the end of the line.")
 	fs.IntVar(&fedo.Count, "count", 1,

--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -1,7 +1,7 @@
 {
 	"plugin": "journald",
 	"pluginConfig": {
-		"source": "docker"
+		"source": "dockerd"
 	},
 	"logPath": "/var/log/journal",
 	"lookback": "5m",

--- a/config/kernel-monitor-counter.json
+++ b/config/kernel-monitor-counter.json
@@ -21,6 +21,8 @@
       "reason": "UnregisterNetDevice",
       "path": "/home/kubernetes/bin/log-counter",
       "args": [
+        "--journald-source=kernel",
+        "--log-path=/var/log/journal",
         "--lookback=20m",
         "--count=3",
         "--pattern=unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"

--- a/config/systemd-monitor-counter.json
+++ b/config/systemd-monitor-counter.json
@@ -1,0 +1,72 @@
+{
+  "plugin": "custom",
+  "pluginConfig": {
+    "invoke_interval": "5m",
+    "timeout": "1m",
+    "max_output_length": 80,
+    "concurrency": 1
+  },
+  "source": "systemd-monitor",
+  "conditions": [
+    {
+      "type": "FrequentKubeletRestart",
+      "reason": "NoFrequentKubeletRestart",
+      "message": "kubelet is functioning properly"
+    },
+    {
+      "type": "FrequentDockerRestart",
+      "reason": "NoFrequentDockerRestart",
+      "message": "docker is functioning properly"
+    },
+    {
+      "type": "FrequentContainerdRestart",
+      "reason": "NoFrequentContainerdRestart",
+      "message": "containerd is functioning properly"
+    }
+  ],
+  "rules": [
+    {
+      "type": "permanent",
+      "condition": "FrequentKubeletRestart",
+      "reason": "FrequentKubeletRestart",
+      "path": "/home/kubernetes/bin/log-counter",
+      "args": [
+        "--journald-source=systemd",
+        "--log-path=/var/log/journal",
+        "--lookback=20m",
+        "--delay=5m",
+        "--count=5",
+        "--pattern=Started Kubernetes kubelet."
+      ],
+      "timeout": "1m"
+    },
+    {
+      "type": "permanent",
+      "condition": "FrequentDockerRestart",
+      "reason": "FrequentDockerRestart",
+      "path": "/home/kubernetes/bin/log-counter",
+      "args": [
+        "--journald-source=systemd",
+        "--log-path=/var/log/journal",
+        "--lookback=20m",
+        "--count=5",
+        "--pattern=Starting Docker Application Container Engine..."
+      ],
+      "timeout": "1m"
+    },
+    {
+      "type": "permanent",
+      "condition": "FrequentContainerdRestart",
+      "reason": "FrequentContainerdRestart",
+      "path": "/home/kubernetes/bin/log-counter",
+      "args": [
+        "--journald-source=systemd",
+        "--log-path=/var/log/journal",
+        "--lookback=20m",
+        "--count=5",
+        "--pattern=Starting containerd container runtime..."
+      ],
+      "timeout": "1m"
+    }
+  ]
+}

--- a/deployment/node-problem-detector-config.yaml
+++ b/deployment/node-problem-detector-config.yaml
@@ -69,7 +69,7 @@ data:
     {
         "plugin": "journald",
         "pluginConfig": {
-            "source": "docker"
+            "source": "dockerd"
         },
         "logPath": "/var/log/journal",
         "lookback": "5m",

--- a/pkg/custompluginmonitor/types/config.go
+++ b/pkg/custompluginmonitor/types/config.go
@@ -37,26 +37,26 @@ var (
 
 type pluginGlobalConfig struct {
 	// InvokeIntervalString is the interval string at which plugins will be invoked.
-	InvokeIntervalString *string `json:"invoke_interval, omitempty"`
+	InvokeIntervalString *string `json:"invoke_interval,omitempty"`
 	// TimeoutString is the global plugin execution timeout string.
-	TimeoutString *string `json:"timeout, omitempty"`
+	TimeoutString *string `json:"timeout,omitempty"`
 	// InvokeInterval is the interval at which plugins will be invoked.
 	InvokeInterval *time.Duration `json:"-"`
 	// Timeout is the global plugin execution timeout.
 	Timeout *time.Duration `json:"-"`
 	// MaxOutputLength is the maximum plugin output message length.
-	MaxOutputLength *int `json:"max_output_length, omitempty"`
+	MaxOutputLength *int `json:"max_output_length,omitempty"`
 	// Concurrency is the number of concurrent running plugins.
-	Concurrency *int `json:"concurrency, omitempty"`
+	Concurrency *int `json:"concurrency,omitempty"`
 }
 
 // Custom plugin config is the configuration of custom plugin monitor.
 type CustomPluginConfig struct {
 	// Plugin is the name of plugin which is currently used.
 	// Currently supported: custom.
-	Plugin string `json:"plugin, omitempty"`
+	Plugin string `json:"plugin,omitempty"`
 	// PluginConfig is global plugin configuration.
-	PluginGlobalConfig pluginGlobalConfig `json:"pluginConfig, omitempty"`
+	PluginGlobalConfig pluginGlobalConfig `json:"pluginConfig,omitempty"`
 	// Source is the source name of the custom plugin monitor
 	Source string `json:"source"`
 	// DefaultConditions are the default states of all the conditions custom plugin monitor should handle.

--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_test.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
 	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
+	"k8s.io/node-problem-detector/pkg/util"
 )
 
 type mockKmsgParser struct {
@@ -50,12 +51,17 @@ func TestWatch(t *testing.T) {
 	now := time.Date(time.Now().Year(), time.January, 2, 3, 4, 5, 0, time.Local)
 	fakeClock := fakeclock.NewFakeClock(now)
 	testCases := []struct {
+		uptime   time.Duration
+		lookback string
+		delay    string
 		log      *mockKmsgParser
 		logs     []logtypes.Log
-		lookback string
 	}{
 		{
 			// The start point is at the head of the log file.
+			uptime:   0,
+			lookback: "0",
+			delay:    "0",
 			log: &mockKmsgParser{kmsgs: []kmsgparser.Message{
 				{Message: "1", Timestamp: now.Add(0 * time.Second)},
 				{Message: "2", Timestamp: now.Add(1 * time.Second)},
@@ -75,10 +81,12 @@ func TestWatch(t *testing.T) {
 					Message:   "3",
 				},
 			},
-			lookback: "0",
 		},
 		{
 			// The start point is in the middle of the log file.
+			uptime:   0,
+			lookback: "0",
+			delay:    "0",
 			log: &mockKmsgParser{kmsgs: []kmsgparser.Message{
 				{Message: "1", Timestamp: now.Add(-1 * time.Second)},
 				{Message: "2", Timestamp: now.Add(0 * time.Second)},
@@ -94,16 +102,17 @@ func TestWatch(t *testing.T) {
 					Message:   "3",
 				},
 			},
-			lookback: "0",
 		},
 		{
 			// The start point is at the end of the log file, but we look back.
+			uptime:   2 * time.Second,
+			lookback: "1s",
+			delay:    "0",
 			log: &mockKmsgParser{kmsgs: []kmsgparser.Message{
 				{Message: "1", Timestamp: now.Add(-2 * time.Second)},
 				{Message: "2", Timestamp: now.Add(-1 * time.Second)},
 				{Message: "3", Timestamp: now.Add(0 * time.Second)},
 			}},
-			lookback: "1s",
 			logs: []logtypes.Log{
 				{
 					Timestamp: now.Add(-time.Second),
@@ -115,9 +124,32 @@ func TestWatch(t *testing.T) {
 				},
 			},
 		},
+		{
+			// The start point is at the end of the log file, but we look back up to start time.
+			uptime:   time.Second,
+			lookback: "3s",
+			delay:    "0",
+			log: &mockKmsgParser{kmsgs: []kmsgparser.Message{
+				{Message: "1", Timestamp: now.Add(-3 * time.Second)},
+				{Message: "2", Timestamp: now.Add(-2 * time.Second)},
+				{Message: "3", Timestamp: now.Add(-1 * time.Second)},
+				{Message: "4", Timestamp: now.Add(0 * time.Second)},
+			}},
+			logs: []logtypes.Log{
+				{
+					Timestamp: now.Add(-time.Second),
+					Message:   "3",
+				},
+				{
+					Timestamp: now,
+					Message:   "4",
+				},
+			},
+		},
 	}
 	for _, test := range testCases {
 		w := NewKmsgWatcher(types.WatcherConfig{Lookback: test.lookback})
+		w.(*kernelLogWatcher).startTime, _ = util.GetStartTime(fakeClock.Now(), test.uptime, test.lookback, test.delay)
 		w.(*kernelLogWatcher).clock = fakeClock
 		w.(*kernelLogWatcher).kmsgParser = test.log
 		logCh, err := w.Watch()
@@ -130,7 +162,7 @@ func TestWatch(t *testing.T) {
 			assert.Equal(t, &expected, got)
 		}
 		// The log channel should have already been drained
-		// There could stil be future messages sent into the channel, but the chance is really slim.
+		// There could still be future messages sent into the channel, but the chance is really slim.
 		timeout := time.After(100 * time.Millisecond)
 		select {
 		case log := <-logCh:

--- a/pkg/systemlogmonitor/logwatchers/types/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/types/log_watcher.go
@@ -32,14 +32,18 @@ type LogWatcher interface {
 type WatcherConfig struct {
 	// Plugin is the name of plugin which is currently used.
 	// Currently supported: filelog, journald, kmsg.
-	Plugin string `json:"plugin, omitempty"`
+	Plugin string `json:"plugin,omitempty"`
 	// PluginConfig is a key/value configuration of a plugin. Valid configurations
 	// are defined in different log watcher plugin.
-	PluginConfig map[string]string `json:"pluginConfig, omitempty"`
+	PluginConfig map[string]string `json:"pluginConfig,omitempty"`
 	// LogPath is the path to the log
-	LogPath string `json:"logPath, omitempty"`
+	LogPath string `json:"logPath,omitempty"`
 	// Lookback is the time log watcher looks up
-	Lookback string `json:"lookback, omitempty"`
+	Lookback string `json:"lookback,omitempty"`
+	// Delay is the time duration log watcher delays after node boot time. This is
+	// useful when the log watcher needs to wait for some time until the node
+	// becomes stable.
+	Delay string `json:"delay,omitempty"`
 }
 
 // WatcherCreateFunc is the create function of a log watcher.

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	"fmt"
+	"syscall"
 	"time"
 
 	"k8s.io/node-problem-detector/pkg/types"
@@ -30,4 +31,42 @@ func GenerateConditionChangeEvent(t string, status types.ConditionStatus, reason
 		Reason:    reason,
 		Message:   fmt.Sprintf("Node condition %s is now: %s, reason: %s", t, status, reason),
 	}
+}
+
+func GetUptimeDuration() (time.Duration, error) {
+	var info syscall.Sysinfo_t
+	if err := syscall.Sysinfo(&info); err != nil {
+		return 0, fmt.Errorf("failed to get system info: %v", err)
+	}
+	return time.Duration(info.Uptime) * time.Second, nil
+}
+
+func GetStartTime(now time.Time, uptimeDuration time.Duration, lookbackStr string, delayStr string) (time.Time, error) {
+	startTime := now.Add(-uptimeDuration)
+
+	// Delay startTime if delay duration is set, so that the log watcher can skip
+	// the logs in delay duration and wait until the node is stable.
+	if delayStr != "" {
+		delay, err := time.ParseDuration(delayStr)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("failed to parse delay duration %q: %v", delayStr, err)
+		}
+		// Notice that when delay > uptime, startTime is actually after now, which is fine.
+		startTime = startTime.Add(delay)
+	}
+
+	// Addjust startTime according to lookback duration
+	lookbackStartTime := now
+	if lookbackStr != "" {
+		lookback, err := time.ParseDuration(lookbackStr)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("failed to parse lookback duration %q: %v", lookbackStr, err)
+		}
+		lookbackStartTime = now.Add(-lookback)
+	}
+	if startTime.Before(lookbackStartTime) {
+		startTime = lookbackStartTime
+	}
+
+	return startTime, nil
 }

--- a/pkg/util/helpers_test.go
+++ b/pkg/util/helpers_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetStartTime(t *testing.T) {
+	now := time.Now()
+	testCases := []struct {
+		name              string
+		uptime            time.Duration
+		lookback          string
+		delay             string
+		expectErr         bool
+		expectedStartTime time.Time
+	}{
+		{
+			name:              "bad lookback value",
+			uptime:            0,
+			lookback:          "abc",
+			delay:             "",
+			expectErr:         true,
+			expectedStartTime: time.Time{},
+		},
+		{
+			name:              "bad delay value",
+			uptime:            0,
+			lookback:          "",
+			delay:             "abc",
+			expectErr:         true,
+			expectedStartTime: time.Time{},
+		},
+		{
+			name:              "node is just up, no lookback and delay",
+			uptime:            0,
+			lookback:          "",
+			delay:             "",
+			expectErr:         false,
+			expectedStartTime: now,
+		},
+		{
+			name:              "no delay, lookback > uptime",
+			uptime:            5 * time.Second,
+			lookback:          "7s",
+			delay:             "",
+			expectErr:         false,
+			expectedStartTime: now.Add(-5 * time.Second),
+		},
+		{
+			name:              "no delay, lookback < uptime",
+			uptime:            5 * time.Second,
+			lookback:          "3s",
+			delay:             "",
+			expectErr:         false,
+			expectedStartTime: now.Add(-3 * time.Second),
+		},
+		{
+			name:              "no lookback, delay > uptime",
+			uptime:            5 * time.Second,
+			lookback:          "",
+			delay:             "7s",
+			expectErr:         false,
+			expectedStartTime: now.Add(2 * time.Second),
+		},
+		{
+			name:              "no lookback, delay < uptime",
+			uptime:            5 * time.Second,
+			lookback:          "",
+			delay:             "3s",
+			expectErr:         false,
+			expectedStartTime: now,
+		},
+		{
+			name:              "uptime < delay",
+			uptime:            10 * time.Second,
+			lookback:          "6s",
+			delay:             "12s",
+			expectErr:         false,
+			expectedStartTime: now.Add(2 * time.Second),
+		},
+		{
+			name:              "uptime > delay, uptime < lookback",
+			uptime:            10 * time.Second,
+			lookback:          "12s",
+			delay:             "7s",
+			expectErr:         false,
+			expectedStartTime: now.Add(-3 * time.Second),
+		},
+		{
+			name:              "uptime > delay, uptime > lookback, lookback > uptime - delay",
+			uptime:            10 * time.Second,
+			lookback:          "6s",
+			delay:             "7s",
+			expectErr:         false,
+			expectedStartTime: now.Add(-3 * time.Second),
+		},
+		{
+			name:              "uptime > delay, uptime > lookback, lookback < uptime - delay",
+			uptime:            10 * time.Second,
+			lookback:          "2s",
+			delay:             "7s",
+			expectErr:         false,
+			expectedStartTime: now.Add(-2 * time.Second),
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			startTime, err := GetStartTime(now, test.uptime, test.lookback, test.delay)
+			if test.expectErr && err == nil {
+				t.Fatalf("Expect to get error, but got no returned error.")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("Expect to get no error, but got returned error: %v", err)
+			}
+			if test.expectedStartTime != startTime {
+				t.Fatalf("Expect to get start time %v, but got %v", test.expectedStartTime, startTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds customer plugin that watch systemd logs for frequent kubelet and container runtime restarts. It reuses log counter for frequent restart detection. Notice that kubelet and container runtime restart logs are actually in systemd logs, not in kubelet or container runtime logs.

Noticeable changes:
- Add delay option to log watchers, so that they can delay watching until the node is stable.
- Change log counter to watch journald instead of kmsg.
- Update docker monitor to use `dockerd` as the source name.
- Fix vet errors
- Update README on injecting systemd logs