### PR TITLE
Fix typos: NDDE -> NODE, permenantly -> permanently

### DIFF
--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -44,7 +44,7 @@ func TestSetNodeNameOrDie(t *testing.T) {
 				HostnameOverride: "hostname-override",
 			},
 		},
-		"Check hostname override and NDDE_NAME env": {
+		"Check hostname override and NODE_NAME env": {
 			WantedNodeName: "node-name-env",
 			Meta: options{
 				Nodename:         "node-name-env",

--- a/pkg/logcounter/log_counter_test.go
+++ b/pkg/logcounter/log_counter_test.go
@@ -115,7 +115,7 @@ func TestCount(t *testing.T) {
 				for _, log := range logs {
 					ch <- log
 				}
-				// trigger the timeout to ensure the test doesn't block permenantly
+				// trigger the timeout to ensure the test doesn't block permanently
 				for {
 					fakeClock.Step(2 * timeout)
 				}


### PR DESCRIPTION
Fix typos: NDDE -> NODE, permenantly -> permanently