### PR TITLE
More fix to custom plugin monitor condition change

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -176,9 +176,10 @@ func (c *customPluginMonitor) generateStatus(result cpmtypes.Result) *types.Stat
 
 					condition.Status = status
 					condition.Reason = result.Rule.Reason
-				} else if condition.Status == status && condition.Message != result.Message {
-					// change 4: Condition status do not change. condition message changes.
+				} else if condition.Status == status && condition.Reason != result.Rule.Reason {
+					// change 4: Condition status do not change. condition reason changes.
 					condition.Transition = timestamp
+					condition.Reason = result.Rule.Reason
 					condition.Message = result.Message
 					events = append(events, util.GenerateConditionChangeEvent(
 						condition.Type,


### PR DESCRIPTION
When `condition.Status` does not change, we should check `condition.Reason` instead of `condition.Message` because Message could be spammy and change a lot. 

This is part of #202.