### PR TITLE
Update base image for CVE fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
 ENABLE_JOURNALD?=1
 
 # TODO(random-liu): Support different architectures.
-# The debian-base:0.3 image built from kubernetes repository is based on Debian Stretch.
+# The debian-base:0.4.0 image built from kubernetes repository is based on Debian Stretch.
 # It includes systemd 232 with support for both +XZ and +LZ4 compression.
 # +LZ4 is needed on some os distros such as COS.
-BASEIMAGE:=k8s.gcr.io/debian-base-amd64:0.3
+BASEIMAGE:=k8s.gcr.io/debian-base-amd64:0.4.0
 
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0


### PR DESCRIPTION
There are several CVEs in `k8s.gcr.io/debian-base-amd64:0.3`.
![image](https://user-images.githubusercontent.com/5821883/49189677-30543f80-f324-11e8-9078-5469a6378b60.png)

Update the base image to fix those CVEs.
![image](https://user-images.githubusercontent.com/5821883/49189702-42ce7900-f324-11e8-976a-43b36733cb0d.png)
