### PR TITLE
Explicitly include libsystemd0 in the image.

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -15,7 +15,7 @@
 FROM @BASEIMAGE@
 MAINTAINER Random Liu <lantaol@google.com>
 
-RUN clean-install bash
+RUN clean-install libsystemd0 bash
 
 # Avoid symlink of /etc/localtime.
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true


### PR DESCRIPTION
Fixes https://github.com/kubernetes/node-problem-detector/issues/232.

`libsystemd0` was excluded from the base image https://github.com/kubernetes/kubernetes/pull/69995

Explicitly include libsystemd0 because we need it for npd.