### PR TITLE
enable codnition updaet when message change for custom plugin

### DIFF
--- a/config/custom-plugin-monitor.json
+++ b/config/custom-plugin-monitor.json
@@ -4,7 +4,8 @@
     "invoke_interval": "30s",
     "timeout": "5s",
     "max_output_length": 80,
-    "concurrency": 3
+    "concurrency": 3,
+    "enable_message_change_based_condition_update": false
   },
   "source": "ntp-custom-plugin-monitor",
   "conditions": [

--- a/docs/custom_plugin_monitor.md
+++ b/docs/custom_plugin_monitor.md
@@ -6,3 +6,4 @@
 * `timeout`: Time after which custom plugins invokation will be terminated and considered timeout.
 * `max_output_length`: The maximum standard output size from custom plugins that NPD will be cut and use for condition status message.
 * `concurrency`: The plugin worker number, i.e., how many custom plugins will be invoked concurrently.
+* `enable_message_change_based_condition_update`: Flag controls whether message change should result in a condition update.

--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -176,8 +176,12 @@ func (c *customPluginMonitor) generateStatus(result cpmtypes.Result) *types.Stat
 
 					condition.Status = status
 					condition.Reason = result.Rule.Reason
-				} else if condition.Status == status && condition.Reason != result.Rule.Reason {
-					// change 4: Condition status do not change. condition reason changes.
+				} else if condition.Status == status &&
+					(condition.Reason != result.Rule.Reason ||
+						(*c.config.PluginGlobalConfig.EnableMessageChangeBasedConditionUpdate && condition.Message != result.Message)) {
+					// change 4: Condition status do not change.
+					// condition reason changes or
+					// condition message changes when message based condition update is enabled.
 					condition.Transition = timestamp
 					condition.Reason = result.Rule.Reason
 					condition.Message = result.Message

--- a/pkg/custompluginmonitor/types/config.go
+++ b/pkg/custompluginmonitor/types/config.go
@@ -25,12 +25,13 @@ import (
 )
 
 var (
-	defaultGlobalTimeout        = 5 * time.Second
-	defaultGlobalTimeoutString  = defaultGlobalTimeout.String()
-	defaultInvokeInterval       = 30 * time.Second
-	defaultInvokeIntervalString = defaultInvokeInterval.String()
-	defaultMaxOutputLength      = 80
-	defaultConcurrency          = 3
+	defaultGlobalTimeout                     = 5 * time.Second
+	defaultGlobalTimeoutString               = defaultGlobalTimeout.String()
+	defaultInvokeInterval                    = 30 * time.Second
+	defaultInvokeIntervalString              = defaultInvokeInterval.String()
+	defaultMaxOutputLength                   = 80
+	defaultConcurrency                       = 3
+	defaultMessageChangeBasedConditionUpdate = false
 
 	customPluginName = "custom"
 )
@@ -48,6 +49,8 @@ type pluginGlobalConfig struct {
 	MaxOutputLength *int `json:"max_output_length,omitempty"`
 	// Concurrency is the number of concurrent running plugins.
 	Concurrency *int `json:"concurrency,omitempty"`
+	// EnableMessageChangeBasedConditionUpdate indicates whether NPD should enable message change based condition update.
+	EnableMessageChangeBasedConditionUpdate *bool `json:"enable_message_change_based_condition_update,omitempty"`
 }
 
 // Custom plugin config is the configuration of custom plugin monitor.
@@ -94,6 +97,9 @@ func (cpc *CustomPluginConfig) ApplyConfiguration() error {
 	}
 	if cpc.PluginGlobalConfig.Concurrency == nil {
 		cpc.PluginGlobalConfig.Concurrency = &defaultConcurrency
+	}
+	if cpc.PluginGlobalConfig.EnableMessageChangeBasedConditionUpdate == nil {
+		cpc.PluginGlobalConfig.EnableMessageChangeBasedConditionUpdate = &defaultMessageChangeBasedConditionUpdate
 	}
 
 	for _, rule := range cpc.Rules {

--- a/pkg/custompluginmonitor/types/config_test.go
+++ b/pkg/custompluginmonitor/types/config_test.go
@@ -29,6 +29,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 	invokeIntervalString := invokeInterval.String()
 	maxOutputLength := 79
 	concurrency := 2
+	messageChangeBasedConditionUpdate := true
 
 	ruleTimeout := 1 * time.Second
 	ruleTimeoutString := ruleTimeout.String()
@@ -51,12 +52,13 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 			},
 			Wanted: CustomPluginConfig{
 				PluginGlobalConfig: pluginGlobalConfig{
-					InvokeIntervalString: &defaultInvokeIntervalString,
-					InvokeInterval:       &defaultInvokeInterval,
-					TimeoutString:        &defaultGlobalTimeoutString,
-					Timeout:              &defaultGlobalTimeout,
-					MaxOutputLength:      &defaultMaxOutputLength,
-					Concurrency:          &defaultConcurrency,
+					InvokeIntervalString:                    &defaultInvokeIntervalString,
+					InvokeInterval:                          &defaultInvokeInterval,
+					TimeoutString:                           &defaultGlobalTimeoutString,
+					Timeout:                                 &defaultGlobalTimeout,
+					MaxOutputLength:                         &defaultMaxOutputLength,
+					Concurrency:                             &defaultConcurrency,
+					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
 				},
 				Rules: []*CustomRule{
 					{
@@ -78,12 +80,13 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 			},
 			Wanted: CustomPluginConfig{
 				PluginGlobalConfig: pluginGlobalConfig{
-					InvokeIntervalString: &invokeIntervalString,
-					InvokeInterval:       &invokeInterval,
-					TimeoutString:        &defaultGlobalTimeoutString,
-					Timeout:              &defaultGlobalTimeout,
-					MaxOutputLength:      &defaultMaxOutputLength,
-					Concurrency:          &defaultConcurrency,
+					InvokeIntervalString:                    &invokeIntervalString,
+					InvokeInterval:                          &invokeInterval,
+					TimeoutString:                           &defaultGlobalTimeoutString,
+					Timeout:                                 &defaultGlobalTimeout,
+					MaxOutputLength:                         &defaultMaxOutputLength,
+					Concurrency:                             &defaultConcurrency,
+					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
 				},
 			},
 		},
@@ -95,12 +98,13 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 			},
 			Wanted: CustomPluginConfig{
 				PluginGlobalConfig: pluginGlobalConfig{
-					InvokeIntervalString: &defaultInvokeIntervalString,
-					InvokeInterval:       &defaultInvokeInterval,
-					TimeoutString:        &globalTimeoutString,
-					Timeout:              &globalTimeout,
-					MaxOutputLength:      &defaultMaxOutputLength,
-					Concurrency:          &defaultConcurrency,
+					InvokeIntervalString:                    &defaultInvokeIntervalString,
+					InvokeInterval:                          &defaultInvokeInterval,
+					TimeoutString:                           &globalTimeoutString,
+					Timeout:                                 &globalTimeout,
+					MaxOutputLength:                         &defaultMaxOutputLength,
+					Concurrency:                             &defaultConcurrency,
+					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
 				},
 			},
 		},
@@ -112,12 +116,13 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 			},
 			Wanted: CustomPluginConfig{
 				PluginGlobalConfig: pluginGlobalConfig{
-					InvokeIntervalString: &defaultInvokeIntervalString,
-					InvokeInterval:       &defaultInvokeInterval,
-					TimeoutString:        &defaultGlobalTimeoutString,
-					Timeout:              &defaultGlobalTimeout,
-					MaxOutputLength:      &maxOutputLength,
-					Concurrency:          &defaultConcurrency,
+					InvokeIntervalString:                    &defaultInvokeIntervalString,
+					InvokeInterval:                          &defaultInvokeInterval,
+					TimeoutString:                           &defaultGlobalTimeoutString,
+					Timeout:                                 &defaultGlobalTimeout,
+					MaxOutputLength:                         &maxOutputLength,
+					Concurrency:                             &defaultConcurrency,
+					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
 				},
 			},
 		},
@@ -129,12 +134,31 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 			},
 			Wanted: CustomPluginConfig{
 				PluginGlobalConfig: pluginGlobalConfig{
-					InvokeIntervalString: &defaultInvokeIntervalString,
-					InvokeInterval:       &defaultInvokeInterval,
-					TimeoutString:        &defaultGlobalTimeoutString,
-					Timeout:              &defaultGlobalTimeout,
-					MaxOutputLength:      &defaultMaxOutputLength,
-					Concurrency:          &concurrency,
+					InvokeIntervalString:                    &defaultInvokeIntervalString,
+					InvokeInterval:                          &defaultInvokeInterval,
+					TimeoutString:                           &defaultGlobalTimeoutString,
+					Timeout:                                 &defaultGlobalTimeout,
+					MaxOutputLength:                         &defaultMaxOutputLength,
+					Concurrency:                             &concurrency,
+					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+				},
+			},
+		},
+		"custom message change based condition update": {
+			Orig: CustomPluginConfig{
+				PluginGlobalConfig: pluginGlobalConfig{
+					EnableMessageChangeBasedConditionUpdate: &messageChangeBasedConditionUpdate,
+				},
+			},
+			Wanted: CustomPluginConfig{
+				PluginGlobalConfig: pluginGlobalConfig{
+					InvokeIntervalString:                    &defaultInvokeIntervalString,
+					InvokeInterval:                          &defaultInvokeInterval,
+					TimeoutString:                           &defaultGlobalTimeoutString,
+					Timeout:                                 &defaultGlobalTimeout,
+					MaxOutputLength:                         &defaultMaxOutputLength,
+					Concurrency:                             &defaultConcurrency,
+					EnableMessageChangeBasedConditionUpdate: &messageChangeBasedConditionUpdate,
 				},
 			},
 		},


### PR DESCRIPTION
Fix #200 

This PR adds a custom global config to control whether NPD should update condition status when message changes.