### PR TITLE
Add log-counter to the Dockerfile

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -21,5 +21,6 @@ RUN clean-install libsystemd0 bash
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true
 
 ADD ./bin/node-problem-detector /node-problem-detector
+ADD ./bin/log-counter /home/kubernetes/bin/log-counter
 ADD config /config
 ENTRYPOINT ["/node-problem-detector", "--system-log-monitors=/config/kernel-monitor.json"]


### PR DESCRIPTION
Hi, I'm getting the `rule path "/home/kubernetes/bin/log-counter" does not exist` when trying to use the `systemd-monitor-counter.json` as a custom plugin monitor. Below is the full log line.

```
F1227 00:23:30.513039       1 custom_plugin_monitor.go:64] Failed to validate custom plugin config {Plugin:custom PluginGlobalConfig:{InvokeIntervalString:0xc0002d7fb0 TimeoutString:0xc0002d7fc0 InvokeInterval:5m0s Timeout:1m0s MaxOutputLength:0xc000133b18 Concurrency:0xc000133b48} Source:systemd-monitor DefaultConditions:[{Type:FrequentKubeletRestart Status: Transition:0001-01-01 00:00:00 +0000 UTC Reason:NoFrequentKubeletRestart Message:kubelet is functioning properly} {Type:FrequentDockerRestart Status: Transition:0001-01-01 00:00:00 +0000 UTC Reason:NoFrequentDockerRestart Message:docker is functioning properly} {Type:FrequentContainerdRestart Status: Transition:0001-01-01 00:00:00 +0000 UTC Reason:NoFrequentContainerdRestart Message:containerd is functioning properly}] Rules:[0xc000118c40 0xc000118d90 0xc000118e00]}: rule path "/home/kubernetes/bin/log-counter" does not exist. Rule: &amp;{Type:permanent Condition:FrequentKubeletRestart Reason:FrequentKubeletRestart Path:/home/kubernetes/bin/log-counter Args:[--journald-source=systemd --log-path=/var/log/journal --lookback=20m --delay=5m --count=5 --pattern=Started Kubernetes kubelet.] TimeoutString:0xc000300000 Timeout:1m0s}
```

This pr adds the missing binary, as required by all the `*-counter.json`, to the container.


