### PR TITLE
Add validation for the required flag

### DIFF
--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -80,6 +80,9 @@ func (npdo *NodeProblemDetectorOptions) ValidOrDie() {
 		panic(fmt.Sprintf("apiserver-override %q is not a valid HTTP URI: %v",
 			npdo.ApiServerOverride, err))
 	}
+	if len(npdo.SystemLogMonitorConfigPaths) == 0 && len(npdo.CustomPluginMonitorConfigPaths) == 0 {
+		panic(fmt.Sprintf("Either --system-log-monitors or --custom-plugin-monitors is required"))
+	}
 }
 
 // SetNodeNameOrDie sets `NodeName` field with valid value.


### PR DESCRIPTION
If `--system-log-monitors` or `--custom-plugin-monitors` are not
specified, npd gave us unclear message.

This patch adds the validation and clear error message.

BEFORE
```
$ ./bin/node-problem-detector --apiserver-override=http://$APISERVER_IP:$APISERVER_INSECURE_PORT?inClusterConfig=false
F0117 13:15:02.298876   12161 node_problem_detector.go:99] Problem detector failed with error: no log monitor is successfully setup
goroutine 1 [running]:
k8s.io/node-problem-detector/vendor/github.com/golang/glog.stacks(0xc000412900, 0xc0002b6000, 0x84, 0xc8)
	/home/knakayam/.go/src/k8s.io/node-problem-detector/vendor/github.com/golang/glog/glog.go:766 +0xd4
k8s.io/node-problem-detector/vendor/github.com/golang/glog.(*loggingT).output(0x1d320a0, 0xc000000003, 0xc00011a630, 0x1a9f55c, 0x18, 0x63, 0x0)
	/home/knakayam/.go/src/k8s.io/node-problem-detector/vendor/github.com/golang/glog/glog.go:717 +0x306
k8s.io/node-problem-detector/vendor/github.com/golang/glog.(*loggingT).printf(0x1d320a0, 0x3, 0x10e4868, 0x26, 0xc00051ff38, 0x1, 0x1)
	/home/knakayam/.go/src/k8s.io/node-problem-detector/vendor/github.com/golang/glog/glog.go:655 +0x14b
k8s.io/node-problem-detector/vendor/github.com/golang/glog.Fatalf(0x10e4868, 0x26, 0xc00051ff38, 0x1, 0x1)
	/home/knakayam/.go/src/k8s.io/node-problem-detector/vendor/github.com/golang/glog/glog.go:1145 +0x67
main.main()
	/home/knakayam/.go/src/k8s.io/node-problem-detector/cmd/node_problem_detector.go:99 +0x4a2
```

AFTER:
```
$ ./bin/node-problem-detector --apiserver-override=http://$APISERVER_IP:$APISERVER_INSECURE_PORT?inClusterConfig=false
panic: Either --system-log-monitors or --custom-plugin-monitors is required

goroutine 1 [running]:
k8s.io/node-problem-detector/cmd/options.(*NodeProblemDetectorOptions).ValidOrDie(0xc00052bc80)
	/home/knakayam/.go/src/k8s.io/node-problem-detector/cmd/options/options.go:84 +0xff
main.main()
	/home/knakayam/.go/src/k8s.io/node-problem-detector/cmd/node_problem_detector.go:65 +0x82
```