### PR TITLE
Run travis against go v1.10 and v1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: required
 dist: trusty
 language: go
 go:
- - 1.9
  - "1.10"
+ - "1.11"
 services:
  - docker
 before_install:


### PR DESCRIPTION
Currently travis is failing on `TestGoroutineLeak` test but it is only
on Go v1.9.

Go v1.9 is not so new version, hence this patch updates to run travis
against v1.10 and v1.11.

ref:
https://travis-ci.org/kubernetes/node-problem-detector/builds/472040385
https://travis-ci.org/kubernetes/node-problem-detector/builds/465834849
https://travis-ci.org/kubernetes/node-problem-detector/builds/465809562

```
--- FAIL: TestGoroutineLeak (0.00s)
	Error Trace:	log_monitor_test.go:154
	Error:		Not equal: 4 (expected)
			        != 3 (actual)
```