### PR TITLE
Fix travis ci file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ sudo: required
 dist: trusty
 language: go
 go:
- - 1.9
+ - "1.9"
  - "1.10"
+ - "1.11"
+ - "1.12"
+ - master
 services:
  - docker
 before_install:
@@ -15,9 +18,6 @@ install:
  - mkdir -p $HOME/gopath/src/k8s.io
  - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/node-problem-detector
  - cd $HOME/gopath/src/k8s.io/node-problem-detector
-jobs:
-  include:
-    - stage: Test
-      script: make test
-    - stage: Build
-      script: make
+script:
+ - make
+ - make test


### PR DESCRIPTION
This PR fixes the travis CI file. Previous problems:
1. There is always a default build step before jobs, which does not include the journald build tag.
2. The jobs only inherit the first golang version, which is 1.9. Version 1.10 is never tested.

Due to constraint on travis, now we combine `make` and `make test` and override the default script. We also add more golang versions here.