### PR TITLE
Fix CI job race condition

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -65,9 +65,8 @@ export NODE_PROBLEM_DETECTOR_TAR_HASH=$(sha1sum ${ROOT_PATH}/node-problem-detect
 export EXTRA_ENVS=NODE_PROBLEM_DETECTOR_IMAGE=${REGISTRY}/node-problem-detector:${TAG}
 EOF
 
-  set -x
+  echo "Written env file ${ROOT_PATH}/${env_file}:"
   cat ${ROOT_PATH}/${env_file}
-  set +x
 }
 
 function build-pr() {
@@ -94,7 +93,7 @@ function build-ci() {
   install-lib
   export UPLOAD_PATH="${NPD_STAGING_PATH}/ci"
   export REGISTRY="${NPD_STAGING_REGISTRY}/ci"
-  export VERSION=$(get-version)
+  export VERSION="$(get-version)-$(date +%Y%m%d.%H%M)"
   export TAG="${VERSION}"
   make push
   write-env-file ${CI_ENV_FILENAME}
@@ -103,6 +102,9 @@ function build-ci() {
 
 function get-ci-env() {
   gsutil cp ${NPD_STAGING_PATH}/ci/${CI_ENV_FILENAME} ${ROOT_PATH}/${CI_ENV_FILENAME}
+
+  echo "Using env file ${ROOT_PATH}/${CI_ENV_FILENAME}:"
+  cat ${ROOT_PATH}/${CI_ENV_FILENAME}
 }
 
 


### PR DESCRIPTION
Current CI job has race condition. The related CI jobs are:
- [ci-npd-build](https://k8s-testgrid.appspot.com/sig-node-node-problem-detector#ci-npd-build): Build and push NPD to staging, push `ci.env` file to staging.
- [ci-npd-e2e-kubernetes-gce-gci](https://k8s-testgrid.appspot.com/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-gci): Download `ci.env` and export the env; then start to run E2E test; when creating the cluster, use the env exported in `ci.env` to download the NPD builds.
- [ci-npd-e2e-kubernetes-gce-ubuntu](https://k8s-testgrid.appspot.com/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu): Similar to the gci one, just running against ubuntu.

The CI jobs are configured to run every 2 hours. The race condition happens as follows:
1. Time `t`:  All 3 CI jobs run. `ci-npd-build` push the new builds to staging (with new sha1 value).
2. Time `t+2hour`: All 3 CI jobs run again. `ci-npd-build` starts to run, but hasn't finished the build. `ci-npd-e2e-kubernetes-gce-gci` downloads the `ci.env` pushed in step 1 at time `t`.
3. Time `t+2hour+2min`: `ci-npd-build` finishes building and pushes a new build to staging.
4. Time `t+2hour+5min`: `ci-npd-e2e-kubernetes-gce-gci` created the cluster and try to download NPD build. It used the old `ci.env` as downloaded in step 2, but the NPD build on staging has been updated to the new build in step 3. Then the sha1 value does not match. NPD installation fails with following error:
```
Mar 19 14:51:37.716008 e2e-69-7abb6-minion-group-23dx configure.sh[787]: Downloading node-problem-detector-v0.6.2-10-g796c8d0.tar.gz.
Mar 19 14:51:37.738122 e2e-69-7abb6-minion-group-23dx configure.sh[787]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Mar 19 14:51:37.738404 e2e-69-7abb6-minion-group-23dx configure.sh[787]:                                  Dload  Upload   Total   Spent    Left  Speed
Mar 19 14:51:38.062481 e2e-69-7abb6-minion-group-23dx configure.sh[787]: [237B blob data]
Mar 19 14:51:38.124829 e2e-69-7abb6-minion-group-23dx configure.sh[787]: == node-problem-detector-v0.6.2-10-g796c8d0.tar.gz corrupted, sha1 f815d9b7fdec53a0363bb77c19b575c8296dc1fe doesn't match expected 2b7e70b122f338bf75c4beb909f6ded0a569c042 ==
Mar 19 14:51:38.125255 e2e-69-7abb6-minion-group-23dx configure.sh[787]: == Hash validation of https://storage.googleapis.com/node-problem-detector-staging/ci/node-problem-detector/node-problem-detector-v0.6.2-10-g796c8d0.tar.gz failed. Retrying. ==
```

This PR adds current time to version and tag, so that the NPD builds will not be overridden. The GCS bucket is configured to only keep the builds for 7 days, so old files will be cleaned up.

Part of https://github.com/kubernetes/node-problem-detector/issues/236.