### PR TITLE
Register gcloud as a Docker credential in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ build-in-docker: clean docker-builder
 	docker run -v `pwd`:/gopath/src/k8s.io/node-problem-detector/ npd-builder:latest bash -c 'cd /gopath/src/k8s.io/node-problem-detector/ && make build-binaries'
 
 push-container: build-container
-	gcloud docker -- push $(IMAGE)
+	gcloud auth configure-docker
+	docker push $(IMAGE)
 
 push-tar: build-tar
 	gsutil cp $(TARBALL) $(UPLOAD_PATH)/node-problem-detector/


### PR DESCRIPTION
`gcloud docker` is deprecated. This PR updates the Makefile to register gcloud as docker credential.

Part of https://github.com/kubernetes/node-problem-detector/issues/236.