### PR TITLE
Support building NPD images in different arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,23 @@ VERSION?=$(shell if [ -d .git ]; then echo `git describe --tags --dirty`; else e
 # TAG is the tag of the container image, default to binary version.
 TAG?=$(VERSION)
 
+ARCH?=amd64
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=k8s.gcr.io/debian-base-amd64:v1.0.0
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=k8s.gcr.io/debian-base-arm:v1.0.0
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=k8s.gcr.io/debian-base-arm64:v1.0.0
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=k8s.gcr.io/debian-base-ppc64le:v1.0.0
+endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=k8s.gcr.io/debian-base-s390x:v1.0.0
+endif
+
 # REGISTRY is the container registry to push into.
 REGISTRY?=staging-k8s.gcr.io
 
@@ -40,20 +57,14 @@ PKG:=k8s.io/node-problem-detector
 PKG_SOURCES:=$(shell find pkg cmd -name '*.go')
 
 # TARBALL is the name of release tar. Include binary version by default.
-TARBALL:=node-problem-detector-$(VERSION).tar.gz
+TARBALL:=node-problem-detector-$(ARCH)-$(VERSION).tar.gz
 
 # IMAGE is the image name of the node problem detector container image.
-IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
+IMAGE:=$(REGISTRY)/node-problem-detector-$(ARCH):$(TAG)
 
 # ENABLE_JOURNALD enables build journald support or not. Building journald support needs libsystemd-dev
 # or libsystemd-journal-dev.
 ENABLE_JOURNALD?=1
-
-# TODO(random-liu): Support different architectures.
-# The debian-base:0.4.0 image built from kubernetes repository is based on Debian Stretch.
-# It includes systemd 232 with support for both +XZ and +LZ4 compression.
-# +LZ4 is needed on some os distros such as COS.
-BASEIMAGE:=k8s.gcr.io/debian-base-amd64:0.4.0
 
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0


### PR DESCRIPTION
Test: `make` generates a .tar.gz file and the exec file node-problem-detector can be upstarted. 