### PR TITLE
Disable glog writing to files for log-counter

### DIFF
--- a/cmd/logcounter/log_counter.go
+++ b/cmd/logcounter/log_counter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -28,6 +29,12 @@ import (
 )
 
 func main() {
+	// Set glog flag so that it does not log to files.
+	if err := flag.Set("logtostderr", "true"); err != nil {
+		fmt.Printf("Failed to set logtostderr=true: %v", err)
+		os.Exit(int(types.Unknown))
+	}
+
 	fedo := options.NewLogCounterOptions()
 	fedo.AddFlags(pflag.CommandLine)
 	pflag.Parse()


### PR DESCRIPTION
On GKE, we encountered issues where NPD creates high amount of log files on node for log-counter with NPD v0.6.0, where we added more custom plugins that are using log counter. 

Log counter is a custom plugin, it is configured to run once per few minutes (e.g. 5min). Every time it runs, it will generate a tmp file. Eventually it can fill the tmp directory. We should just redirect the logs to stderr. Custom plugins are just using stdout as the interface to talk to NPD, so it should be fine.

This problem is similar to https://github.com/kubernetes-sigs/cri-tools/pull/291.