### PR TITLE
fix node-problem-detector --version to not require monitors specify

### DIFF
--- a/cmd/node_problem_detector.go
+++ b/cmd/node_problem_detector.go
@@ -60,14 +60,14 @@ func main() {
 
 	pflag.Parse()
 
-	npdo.SetNodeNameOrDie()
-
-	npdo.ValidOrDie()
-
 	if npdo.PrintVersion {
 		version.PrintVersion()
 		os.Exit(0)
 	}
+
+	npdo.SetNodeNameOrDie()
+
+	npdo.ValidOrDie()
 
 	monitors := make(map[string]types.Monitor)
 	for _, config := range npdo.SystemLogMonitorConfigPaths {


### PR DESCRIPTION
fix: #269 