### PR TITLE
Remove TestGoroutineLeak unit tests.

### DIFF
--- a/pkg/systemlogmonitor/log_monitor_test.go
+++ b/pkg/systemlogmonitor/log_monitor_test.go
@@ -17,15 +17,10 @@ limitations under the License.
 package systemlogmonitor
 
 import (
-	"fmt"
 	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
-	watchertest "k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/testing"
 	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
 	"k8s.io/node-problem-detector/pkg/types"
 	"k8s.io/node-problem-detector/pkg/util"
@@ -142,14 +137,4 @@ func TestGenerateStatus(t *testing.T) {
 			t.Errorf("case %d: expected status %+v, got %+v", c+1, test.expected, got)
 		}
 	}
-}
-
-func TestGoroutineLeak(t *testing.T) {
-	orignal := runtime.NumGoroutine()
-	f := watchertest.NewFakeLogWatcher(10)
-	f.InjectError(fmt.Errorf("unexpected error"))
-	l := &logMonitor{watcher: f}
-	_, err := l.Start()
-	assert.Error(t, err)
-	assert.Equal(t, orignal, runtime.NumGoroutine())
 }

--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_test.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_test.go
@@ -19,7 +19,6 @@ package filelog
 import (
 	"io/ioutil"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
@@ -179,17 +178,4 @@ Jan  2 03:04:05 kernel: [2.000000] 3
 		case <-timeout:
 		}
 	}
-}
-
-func TestGoroutineLeak(t *testing.T) {
-	orignal := runtime.NumGoroutine()
-	w := NewSyslogWatcherOrDie(types.WatcherConfig{
-		Plugin:       "filelog",
-		PluginConfig: getTestPluginConfig(),
-		LogPath:      "/not/exist/path",
-		Lookback:     "10m",
-	})
-	_, err := w.Watch()
-	assert.Error(t, err)
-	assert.Equal(t, orignal, runtime.NumGoroutine())
 }


### PR DESCRIPTION
We are seeing some flakes on these tests because some goroutine fluctuation:
https://github.com/kubernetes/node-problem-detector/pull/275#issuecomment-499306727

Removing the tests, as it's most robust to test leakage in a soak/stress test, rather than unit test.