### PR TITLE
Allow compilation time disabling for each type of Problem Daemon.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,9 @@ install:
 script:
  - make
  - make test
+ - make clean && BUILD_TAGS="disable_custom_plugin_monitor" make
+ - BUILD_TAGS="disable_custom_plugin_monitor" make test
+ - make clean && BUILD_TAGS="disable_system_log_monitor" make
+ - BUILD_TAGS="disable_system_log_monitor" make test
+ - make clean && BUILD_TAGS="disable_system_stats_monitor" make
+ - BUILD_TAGS="disable_system_stats_monitor" make test

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ BASEIMAGE:=k8s.gcr.io/debian-base-amd64:0.4.0
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0
 
+# Construct the "-tags" parameter used by "go build".
+BUILD_TAGS?=""
 ifeq ($(ENABLE_JOURNALD), 1)
 	# Enable journald build tag.
-	BUILD_TAGS:=-tags journald
+	BUILD_TAGS:=$(BUILD_TAGS) journald
 	# Enable cgo because sdjournal needs cgo to compile. The binary will be
 	# dynamically linked if CGO_ENABLED is enabled. This is fine because fedora
 	# already has necessary dynamic library. We can not use `-extldflags "-static"`
@@ -69,6 +71,10 @@ ifeq ($(ENABLE_JOURNALD), 1)
 	# statically linked application.
 	CGO_ENABLED:=1
 endif
+ifneq ($(BUILD_TAGS), "")
+	BUILD_TAGS:=-tags "$(BUILD_TAGS)"
+endif
+
 
 vet:
 	GO111MODULE=on go list -mod vendor $(BUILD_TAGS) ./... | \
@@ -95,7 +101,7 @@ version:
 		-o bin/node-problem-detector \
 		-ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
 		$(BUILD_TAGS) \
-		./cmd/node-problem-detector
+		./cmd/nodeproblemdetector
 
 Dockerfile: Dockerfile.in
 	sed -e 's|@BASEIMAGE@|$(BASEIMAGE)|g' $< >$@

--- a/README.md
+++ b/README.md
@@ -52,14 +52,19 @@ Currently, a problem daemon is running as a goroutine in the node-problem-detect
 binary. In the future, we'll separate node-problem-detector and problem daemons into
 different containers, and compose them with pod specification.
 
+Each catagory of problem daemon can be disabled at compilation time by setting
+corresponding build tags. If they are disabled at compilation time, then all their
+build dependencies, global variables and background goroutines will be trimmed out
+of the compiled executable.
+
 List of supported problem daemons:
 
-| Problem Daemon |  NodeCondition  | Description |
-|----------------|:---------------:|:------------|
-| [KernelMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) | KernelDeadlock | A system log monitor monitors kernel log and reports problem according to predefined rules. |
-| [AbrtAdaptor](https://github.com/kubernetes/node-problem-detector/blob/master/config/abrt-adaptor.json) | None | Monitor ABRT log messages and report them further. ABRT (Automatic Bug Report Tool) is health monitoring daemon able to catch kernel problems as well as application crashes of various kinds occurred on the host. For more information visit the [link](https://github.com/abrt). |
-| [CustomPluginMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/custom-plugin-monitor.json) | On-demand(According to users configuration) | A custom plugin monitor for node-problem-detector to invoke and check various node problems with user defined check scripts. See proposal [here](https://docs.google.com/document/d/1jK_5YloSYtboj-DtfjmYKxfNnUxCAvohLnsH5aGCAYQ/edit#). |
-| [SystemStatsMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/system-stats-monitor.json) | None(Could be added in the future) | A system stats monitor for node-problem-detector to collect various health-related system stats as metrics. See proposal [here](https://docs.google.com/document/d/1SeaUz6kBavI283Dq8GBpoEUDrHA2a795xtw0OvjM568/edit). |
+| Problem Daemon |  NodeCondition  | Description | Disabling Build Tag |
+|----------------|:---------------:|:------------|:--------------------|
+| [KernelMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) | KernelDeadlock | A system log monitor monitors kernel log and reports problem according to predefined rules. | disable_system_log_monitor
+| [AbrtAdaptor](https://github.com/kubernetes/node-problem-detector/blob/master/config/abrt-adaptor.json) | None | Monitor ABRT log messages and report them further. ABRT (Automatic Bug Report Tool) is health monitoring daemon able to catch kernel problems as well as application crashes of various kinds occurred on the host. For more information visit the [link](https://github.com/abrt). | disable_system_log_monitor
+| [CustomPluginMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/custom-plugin-monitor.json) | On-demand(According to users configuration) | A custom plugin monitor for node-problem-detector to invoke and check various node problems with user defined check scripts. See proposal [here](https://docs.google.com/document/d/1jK_5YloSYtboj-DtfjmYKxfNnUxCAvohLnsH5aGCAYQ/edit#). | disable_custom_plugin_monitor
+| [SystemStatsMonitor](https://github.com/kubernetes/node-problem-detector/blob/master/config/system-stats-monitor.json) | None(Could be added in the future) | A system stats monitor for node-problem-detector to collect various health-related system stats as metrics. See proposal [here](https://docs.google.com/document/d/1SeaUz6kBavI283Dq8GBpoEUDrHA2a795xtw0OvjM568/edit). | disable_system_stats_monitor
 
 # Exporter
 
@@ -116,6 +121,18 @@ with one of the below directions:
 * run `make` in the top directory. It will:
   * Build the binary.
   * Build the docker image. The binary and `config/` are copied into the docker image.
+
+If you do not need certain categories of problem daemons, you could choose to disable them at compilation time. This is the
+best way of keeping your node-problem-detector runtime compact without unnecessary code (e.g. global
+variables, goroutines, etc). You can do so via setting the `BUILD_TAGS` environment variable
+before running `make`. For example:
+
+`BUILD_TAGS="disable_custom_plugin_monitor disable_system_stats_monitor" make`
+
+Above command will compile the node-problem-detector without [Custom Plugin Monitor](https://github.com/kubernetes/node-problem-detector/tree/master/pkg/custompluginmonitor)
+and [System Stats Monitor](https://github.com/kubernetes/node-problem-detector/tree/master/pkg/systemstatsmonitor).
+Check out the [Problem Daemon](https://github.com/kubernetes/node-problem-detector#problem-daemon) section
+to see how to disable each problem daemon during compilation time.
 
 **Note**:
 By default node-problem-detector will be built with systemd support with `make` command. This requires systemd develop files.

--- a/cmd/nodeproblemdetector/node_problem_detector.go
+++ b/cmd/nodeproblemdetector/node_problem_detector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/node-problem-detector/cmd/options"
+	_ "k8s.io/node-problem-detector/cmd/nodeproblemdetector/problemdaemonplugins"
 	"k8s.io/node-problem-detector/pkg/exporters/k8sexporter"
 	"k8s.io/node-problem-detector/pkg/exporters/prometheusexporter"
 	"k8s.io/node-problem-detector/pkg/problemdaemon"

--- a/cmd/nodeproblemdetector/problemdaemonplugins/custom_plugin_monitor_plugin.go
+++ b/cmd/nodeproblemdetector/problemdaemonplugins/custom_plugin_monitor_plugin.go
@@ -1,0 +1,23 @@
+// +build !disable_custom_plugin_monitor
+
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package problemdaemonplugins
+
+import (
+	_ "k8s.io/node-problem-detector/pkg/custompluginmonitor"
+)

--- a/cmd/nodeproblemdetector/problemdaemonplugins/system_log_monitor_plugin.go
+++ b/cmd/nodeproblemdetector/problemdaemonplugins/system_log_monitor_plugin.go
@@ -1,0 +1,23 @@
+// +build !disable_system_log_monitor
+
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package problemdaemonplugins
+
+import (
+	_ "k8s.io/node-problem-detector/pkg/systemlogmonitor"
+)

--- a/cmd/nodeproblemdetector/problemdaemonplugins/system_stats_monitor_plugin.go
+++ b/cmd/nodeproblemdetector/problemdaemonplugins/system_stats_monitor_plugin.go
@@ -1,3 +1,5 @@
+// +build !disable_system_stats_monitor
+
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.
 
@@ -14,11 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package problemdaemonplugins
 
-// register problem daemons here
 import (
-	_ "k8s.io/node-problem-detector/pkg/custompluginmonitor"
-	_ "k8s.io/node-problem-detector/pkg/systemlogmonitor"
 	_ "k8s.io/node-problem-detector/pkg/systemstatsmonitor"
 )


### PR DESCRIPTION
This PR is to implement below action item in #284 : 

- [ x ] Implement option for disabling problem daemons at compile time.


The PR does so by adding build tag on the code that inserts the problem daemon plugins. In current design:
* All problem daemons are included in the NPD binary by default. 
* By setting the `BUILD_TAGS` environment variable, `make` will set the build tags which disables the corresponding type of problem daemon.

Test steps:
1. `make clean && make && bin/node-problem-detector --help`

```
Usage of bin/node-problem-detector:
...
      --config.custom-plugin-monitor strings   Comma separated configurations for custom-plugin-monitor monitor. Set to config file paths.
      --config.system-log-monitor strings      Comma separated configurations for system-log-monitor monitor. Set to config file paths.
      --config.system-stats-monitor strings    Comma separated configurations for system-stats-monitor monitor. Set to config file paths.
...
```

2. `make clean && BUILD_TAGS="disable_custom_plugin_monitor disable_system_stats_monitor" make && bin/node-problem-detector --help`

```
Usage of bin/node-problem-detector:
...
      --config.system-log-monitor strings      Comma separated configurations for system-log-monitor monitor. Set to config file paths.
...
```

3. `make clean && BUILD_TAGS="disable_custom_plugin_monitor disable_system_log_monitor disable_system_stats_monitor" make`

```
...
CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build \
	-mod vendor \
	-o bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.6.4-11-g7b424b6' \
	-tags " journald disable_custom_plugin_monitor disable_system_log_monitor disable_system_stats_monitor" \
	./cmd/nodeproblemdetector
cmd/nodeproblemdetector/node_problem_detector.go:26:2: build constraints exclude all Go files in /usr/local/google/home/xueweiz/.gvm/pkgsets/go1.11/global/src/k8s.io/node-problem-detector/cmd/nodeproblemdetector/problemdaemonplugins
Makefile:105: recipe for target 'bin/node-problem-detector' failed
make: *** [bin/node-problem-detector] Error 1
```