### PR TITLE
Update the detection method for docker overlay2 issue

### DIFF
--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -8,12 +8,24 @@
 	"bufferSize": 10,
 	"source": "docker-monitor",
 	"metricsReporting": true,
-	"conditions": [],
+	"conditions": [
+		{
+			"type": "CorruptDockerOverlay2",
+			"reason": "NoCorruptDockerOverlay2",
+			"message": "docker overlay2 is functioning properly"
+		}
+	],
 	"rules": [
 		{
 			"type": "temporary",
 			"reason": "CorruptDockerImage",
 			"pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
+		},
+		{
+			"type": "permanent",
+			"condition": "CorruptDockerOverlay2",
+			"reason": "CorruptDockerOverlay2",
+			"pattern": "returned error: readlink /var/lib/docker/overlay2.*: invalid argument.*"
 		}
 	]
 }

--- a/test/build.sh
+++ b/test/build.sh
@@ -101,13 +101,12 @@ function build-npd-custom-flags() {
   local -r sm_config="${kube_home}/node-problem-detector/config/systemd-monitor.json"
 
   local -r custom_km_config="${kube_home}/node-problem-detector/config/kernel-monitor-counter.json"
-  local -r custom_dm_config="${kube_home}/node-problem-detector/config/docker-monitor-counter.json"
   local -r custom_sm_config="${kube_home}/node-problem-detector/config/systemd-monitor-counter.json"
 
   flags="--v=2"
   flags+=" --logtostderr"
   flags+=" --config.system-log-monitor=${km_config},${dm_config},${sm_config}"
-  flags+=" --config.custom-plugin-monitor=${custom_km_config},${custom_dm_config},${custom_sm_config}"
+  flags+=" --config.custom-plugin-monitor=${custom_km_config},${custom_sm_config}"
   flags+=" --port=20256"
 
   export NODE_PROBLEM_DETECTOR_CUSTOM_FLAGS=${flags}


### PR DESCRIPTION
This PR updates the detection method for docker overlay2 issue. We no longer count how many times the log message is seen. 