### PR TITLE
Move NPD into kube-system namespace

### DIFF
--- a/deployment/node-problem-detector-config.yaml
+++ b/deployment/node-problem-detector-config.yaml
@@ -87,4 +87,4 @@ data:
 kind: ConfigMap
 metadata:
   name: node-problem-detector-config
-  namespace: default
+  namespace: kube-system

--- a/deployment/node-problem-detector-old.yaml
+++ b/deployment/node-problem-detector-old.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: node-problem-detector
+  namespace: kube-system
 spec:
   template:
     metadata:

--- a/deployment/node-problem-detector.yaml
+++ b/deployment/node-problem-detector.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: node-problem-detector
+  namespace: kube-system
   labels:
     app: node-problem-detector
 spec:


### PR DESCRIPTION
I think it's better to put NPD in kube-system namespace.