### PR TITLE
Metric format fixes on host/uptime and disk/*

### DIFF
--- a/pkg/systemstatsmonitor/host_collector.go
+++ b/pkg/systemstatsmonitor/host_collector.go
@@ -26,12 +26,13 @@ import (
 )
 
 type hostCollector struct {
-	tags   map[string]string
-	uptime *metrics.Int64Metric
+	tags       map[string]string
+	uptime     *metrics.Int64Metric
+	lastUptime int64
 }
 
 func NewHostCollectorOrDie(hostConfig *ssmtypes.HostStatsConfig) *hostCollector {
-	hc := hostCollector{map[string]string{}, nil}
+	hc := hostCollector{map[string]string{}, nil, 0}
 
 	kernelVersion, err := host.KernelVersion()
 	if err != nil {
@@ -45,12 +46,13 @@ func NewHostCollectorOrDie(hostConfig *ssmtypes.HostStatsConfig) *hostCollector 
 	}
 	hc.tags["os_version"] = osVersion
 
+	// Use metrics.Sum aggregation method to ensure the metric is a counter/cumulative metric.
 	if hostConfig.MetricsConfigs["host/uptime"].DisplayName != "" {
 		hc.uptime, err = metrics.NewInt64Metric(
 			hostConfig.MetricsConfigs["host/uptime"].DisplayName,
 			"The uptime of the operating system",
 			"second",
-			metrics.LastValue,
+			metrics.Sum,
 			[]string{"kernel_version", "os_version"})
 		if err != nil {
 			glog.Fatalf("Error initializing metric for host/uptime: %v", err)
@@ -70,8 +72,10 @@ func (hc *hostCollector) collect() {
 		glog.Errorf("Failed to retrieve uptime of the host: %v", err)
 		return
 	}
+	uptimeSeconds := int64(uptime)
 
 	if hc.uptime != nil {
-		hc.uptime.Record(hc.tags, int64(uptime))
+		hc.uptime.Record(hc.tags, uptimeSeconds-hc.lastUptime)
 	}
+	hc.lastUptime = uptimeSeconds
 }


### PR DESCRIPTION
1. host/uptime, disk/io_time and disk/weighted_io should be
counter/cumulative metrics. SO we have to use the Sum aggregation method
rather than LastValue aggregation method (which will declare the metric
as gauge metric).

2. Renamed label "device" for disk/* metrics to "device_name".
This is to clarify that it is device_name (sda1) rather than device_path
(/dev/sda1)

This is for #333 

Tested manually & locally:
`make ./bin/node-problem-detector && ./bin/node-problem-detector --config.system-log-monitor=./config/kernel-monitor.json --config.system-stats-monitor=./config/system-stats-monitor.json --logtostderr --enable-k8s-exporter=false`

```
$ curl http://localhost:20257/metrics
# HELP disk_avg_queue_len The average queue length on the disk
# TYPE disk_avg_queue_len gauge
disk_avg_queue_len{device_name="nvme0n1"} 1.060644164529796
disk_avg_queue_len{device_name="nvme0n1p2"} 63.81818181818182
disk_avg_queue_len{device_name="nvme0n1p3"} 1.1164383561643836
# HELP disk_io_time The IO time spent on the disk
# TYPE disk_io_time counter
disk_io_time{device_name="nvme0n1"} 7.8483924e+07
disk_io_time{device_name="nvme0n1p2"} 88
disk_io_time{device_name="nvme0n1p3"} 584
# HELP disk_weighted_io The weighted IO on the disk
# TYPE disk_weighted_io counter
disk_weighted_io{device_name="nvme0n1"} 8.3243516e+07
disk_weighted_io{device_name="nvme0n1p2"} 5616
disk_weighted_io{device_name="nvme0n1p3"} 652
# HELP host_uptime The uptime of the operating system
# TYPE host_uptime counter
host_uptime{kernel_version="4.19.37-5+deb10u1rodete1-amd64",os_version="debian 10 (buster)"} 94203
# HELP problem_counter Number of times a specific type of problem have occurred.
# TYPE problem_counter counter
problem_counter{reason="AUFSUmountHung"} 0
problem_counter{reason="DockerHung"} 0
problem_counter{reason="FilesystemIsReadOnly"} 0
problem_counter{reason="KernelOops"} 0
problem_counter{reason="OOMKilling"} 0
problem_counter{reason="TaskHung"} 0
problem_counter{reason="UnregisterNetDevice"} 0
# HELP problem_gauge Whether a specific type of problem is affecting the node or not.
# TYPE problem_gauge gauge
problem_gauge{reason="AUFSUmountHung",type="KernelDeadlock"} 0
problem_gauge{reason="DockerHung",type="KernelDeadlock"} 0
problem_gauge{reason="FilesystemIsReadOnly",type="ReadonlyFilesystem"} 0
```