### PR TITLE
avoid log channel closed caused endless loop

### DIFF
--- a/pkg/systemlogmonitor/log_monitor.go
+++ b/pkg/systemlogmonitor/log_monitor.go
@@ -129,7 +129,11 @@ func (l *logMonitor) monitorLoop() {
 	l.initializeStatus()
 	for {
 		select {
-		case log := <-l.logCh:
+		case log, ok := <-l.logCh:
+			if !ok {
+				glog.Errorf("Log channel closed")
+				return
+			}
 			l.parseLog(log)
 		case <-l.tomb.Stopping():
 			l.watcher.Stop()


### PR DESCRIPTION
if log watcher meets error and closes logCh, log monitor will enter endless for loop