### PR TITLE
Make all existing exporters into plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,7 @@ script:
  - BUILD_TAGS="disable_system_stats_monitor" make test
  - make clean && BUILD_TAGS="disable_stackdriver_exporter" make
  - BUILD_TAGS="disable_stackdriver_exporter" make test
+ - make clean && BUILD_TAGS="disable_k8s_exporter" make
+ - BUILD_TAGS="disable_k8s_exporter" make test
+ - make clean && BUILD_TAGS="disable_prometheus_exporter" make
+ - BUILD_TAGS="disable_prometheus_exporter" make test

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ certain back end. Some of them can be disable at compile time using a build tag.
 
 | Exporter |Description | Disabling Build Tag |
 |----------|:-----------|:--------------------|
-| Kubernetes exporter | Kubernetes exporter reports node problems to Kubernetes API server: temporary problems get reported as Events, and permanent problems get reported as Node Conditions. | 
-| Prometheus exporter | Prometheus exporter reports node problems and metrics locally as Prometheus metrics | 
+| Kubernetes exporter | Kubernetes exporter reports node problems to Kubernetes API server: temporary problems get reported as Events, and permanent problems get reported as Node Conditions. | disable_k8s_exporter
+| Prometheus exporter | Prometheus exporter reports node problems and metrics locally as Prometheus metrics | disable_prometheus_exporter
 | [Stackdriver exporter](https://github.com/kubernetes/node-problem-detector/blob/master/config/exporter/stackdriver-exporter.json) | Stackdriver exporter reports node problems and metrics to Stackdriver Monitoring API. | disable_stackdriver_exporter
 
 # Usage

--- a/cmd/nodeproblemdetector/exporterplugins/k8s_exporter_plugin.go
+++ b/cmd/nodeproblemdetector/exporterplugins/k8s_exporter_plugin.go
@@ -1,3 +1,5 @@
+// +build !disable_k8s_exporter
+
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.
 
@@ -16,5 +18,8 @@ limitations under the License.
 
 package exporterplugins
 
-// This file is necessary to make sure the exporterplugins package non-empty
-// under any build tags.
+import (
+	_ "k8s.io/node-problem-detector/pkg/exporters/k8sexporter"
+)
+
+// The stackdriver plugin takes about 6MB in the NPD binary.

--- a/cmd/nodeproblemdetector/exporterplugins/prometheus_exporter_plugin.go
+++ b/cmd/nodeproblemdetector/exporterplugins/prometheus_exporter_plugin.go
@@ -1,0 +1,25 @@
+// +build !disable_prometheus_exporter
+
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exporterplugins
+
+import (
+	_ "k8s.io/node-problem-detector/pkg/exporters/prometheusexporter"
+)
+
+// The stackdriver plugin takes about 6MB in the NPD binary.

--- a/cmd/nodeproblemdetector/node_problem_detector.go
+++ b/cmd/nodeproblemdetector/node_problem_detector.go
@@ -26,11 +26,8 @@ import (
 	_ "k8s.io/node-problem-detector/cmd/nodeproblemdetector/problemdaemonplugins"
 	"k8s.io/node-problem-detector/cmd/options"
 	"k8s.io/node-problem-detector/pkg/exporters"
-	"k8s.io/node-problem-detector/pkg/exporters/k8sexporter"
-	"k8s.io/node-problem-detector/pkg/exporters/prometheusexporter"
 	"k8s.io/node-problem-detector/pkg/problemdaemon"
 	"k8s.io/node-problem-detector/pkg/problemdetector"
-	"k8s.io/node-problem-detector/pkg/types"
 	"k8s.io/node-problem-detector/pkg/version"
 )
 
@@ -55,22 +52,7 @@ func main() {
 	}
 
 	// Initialize exporters.
-	defaultExporters := []types.Exporter{}
-	if ke := k8sexporter.NewExporterOrDie(npdo); ke != nil {
-		defaultExporters = append(defaultExporters, ke)
-		glog.Info("K8s exporter started.")
-	}
-	if pe := prometheusexporter.NewExporterOrDie(npdo); pe != nil {
-		defaultExporters = append(defaultExporters, pe)
-		glog.Info("Prometheus exporter started.")
-	}
-
-	plugableExporters := exporters.NewExporters()
-
-	npdExporters := []types.Exporter{}
-	npdExporters = append(npdExporters, defaultExporters...)
-	npdExporters = append(npdExporters, plugableExporters...)
-
+	npdExporters := exporters.NewExporters()
 	if len(npdExporters) == 0 {
 		glog.Fatalf("No exporter is successfully setup")
 	}

--- a/cmd/nodeproblemdetector/node_problem_detector.go
+++ b/cmd/nodeproblemdetector/node_problem_detector.go
@@ -45,7 +45,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	npdo.SetNodeNameOrDie()
 	npdo.SetConfigFromDeprecatedOptionsOrDie()
 	npdo.ValidOrDie()
 

--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -19,7 +19,6 @@ package options
 import (
 	"flag"
 	"fmt"
-	"os"
 	"time"
 
 	"net/url"
@@ -80,11 +79,6 @@ type NodeProblemDetectorOptions struct {
 	CustomPluginMonitorConfigPaths []string
 	// MonitorConfigPaths specifies the list of paths to configuration files for each monitor.
 	MonitorConfigPaths types.ProblemDaemonConfigPathMap
-
-	// application options
-
-	// NodeName is the node name used to communicate with Kubernetes ApiServer.
-	NodeName string
 }
 
 func NewNodeProblemDetectorOptions() *NodeProblemDetectorOptions {
@@ -206,36 +200,6 @@ func (npdo *NodeProblemDetectorOptions) SetConfigFromDeprecatedOptionsOrDie() {
 			npdo.CustomPluginMonitorConfigPaths...)
 		npdo.CustomPluginMonitorConfigPaths = []string{}
 	}
-}
-
-// SetNodeNameOrDie sets `NodeName` field with valid value.
-func (npdo *NodeProblemDetectorOptions) SetNodeNameOrDie() {
-	// Check hostname override first for customized node name.
-	if npdo.HostnameOverride != "" {
-		npdo.NodeName = npdo.HostnameOverride
-		return
-	}
-
-	// Get node name from environment variable NODE_NAME
-	// By default, assume that the NODE_NAME env should have been set with
-	// downward api or user defined exported environment variable. We prefer it because sometimes
-	// the hostname returned by os.Hostname is not right because:
-	// 1. User may override the hostname.
-	// 2. For some cloud providers, os.Hostname is different from the real hostname.
-	npdo.NodeName = os.Getenv("NODE_NAME")
-	if npdo.NodeName != "" {
-		return
-	}
-
-	// For backward compatibility. If the env is not set, get the hostname
-	// from os.Hostname(). This may not work for all configurations and
-	// environments.
-	nodeName, err := os.Hostname()
-	if err != nil {
-		panic(fmt.Sprintf("Failed to get host name: %v", err))
-	}
-
-	npdo.NodeName = nodeName
 }
 
 func init() {

--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -19,9 +19,6 @@ package options
 import (
 	"flag"
 	"fmt"
-	"time"
-
-	"net/url"
 
 	"github.com/spf13/pflag"
 
@@ -36,34 +33,6 @@ type NodeProblemDetectorOptions struct {
 
 	// PrintVersion is the flag determining whether version information is printed.
 	PrintVersion bool
-	// HostnameOverride specifies custom node name used to override hostname.
-	HostnameOverride string
-	// ServerPort is the port to bind the node problem detector server. Use 0 to disable.
-	ServerPort int
-	// ServerAddress is the address to bind the node problem detector server.
-	ServerAddress string
-
-	// exporter options
-
-	// k8sExporter options
-	// EnableK8sExporter is the flag determining whether to report to Kubernetes.
-	EnableK8sExporter bool
-	// ApiServerOverride is the custom URI used to connect to Kubernetes ApiServer.
-	ApiServerOverride string
-	// APIServerWaitTimeout is the timeout on waiting for kube-apiserver to be
-	// ready.
-	APIServerWaitTimeout time.Duration
-	// APIServerWaitInterval is the interval between the checks on the
-	// readiness of kube-apiserver.
-	APIServerWaitInterval time.Duration
-	// K8sExporterHeartbeatPeriod is the period at which the k8s exporter does forcibly sync with apiserver.
-	K8sExporterHeartbeatPeriod time.Duration
-
-	// prometheusExporter options
-	// PrometheusServerPort is the port to bind the Prometheus scrape endpoint. Use 0 to disable.
-	PrometheusServerPort int
-	// PrometheusServerAddress is the address to bind the Prometheus scrape endpoint.
-	PrometheusServerAddress string
 
 	// problem daemon options
 
@@ -98,24 +67,8 @@ func (npdo *NodeProblemDetectorOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&npdo.CustomPluginMonitorConfigPaths, "custom-plugin-monitors",
 		[]string{}, "List of paths to custom plugin monitor config files, comma separated.")
 	fs.MarkDeprecated("custom-plugin-monitors", "replaced by --config.custom-plugin-monitor. NPD will panic if both --custom-plugin-monitors and --config.custom-plugin-monitor are set.")
-	fs.BoolVar(&npdo.EnableK8sExporter, "enable-k8s-exporter", true, "Enables reporting to Kubernetes API server.")
-	fs.StringVar(&npdo.ApiServerOverride, "apiserver-override",
-		"", "Custom URI used to connect to Kubernetes ApiServer. This is ignored if --enable-k8s-exporter is false.")
-	fs.DurationVar(&npdo.APIServerWaitTimeout, "apiserver-wait-timeout", time.Duration(5)*time.Minute, "The timeout on waiting for kube-apiserver to be ready. This is ignored if --enable-k8s-exporter is false.")
-	fs.DurationVar(&npdo.APIServerWaitInterval, "apiserver-wait-interval", time.Duration(5)*time.Second, "The interval between the checks on the readiness of kube-apiserver. This is ignored if --enable-k8s-exporter is false.")
-	fs.DurationVar(&npdo.K8sExporterHeartbeatPeriod, "k8s-exporter-heartbeat-period", 5*time.Minute, "The period at which k8s-exporter does forcibly sync with apiserver.")
-	fs.BoolVar(&npdo.PrintVersion, "version", false, "Print version information and quit")
-	fs.StringVar(&npdo.HostnameOverride, "hostname-override",
-		"", "Custom node name used to override hostname")
-	fs.IntVar(&npdo.ServerPort, "port",
-		20256, "The port to bind the node problem detector server. Use 0 to disable.")
-	fs.StringVar(&npdo.ServerAddress, "address",
-		"127.0.0.1", "The address to bind the node problem detector server.")
 
-	fs.IntVar(&npdo.PrometheusServerPort, "prometheus-port",
-		20257, "The port to bind the Prometheus scrape endpoint. Prometheus exporter is enabled by default at port 20257. Use 0 to disable.")
-	fs.StringVar(&npdo.PrometheusServerAddress, "prometheus-address",
-		"127.0.0.1", "The address to bind the Prometheus scrape endpoint.")
+	fs.BoolVar(&npdo.PrintVersion, "version", false, "Print version information and quit")
 
 	for _, exporterName := range exporters.GetExporterNames() {
 		exporterHandler := exporters.GetExporterHandlerOrDie(exporterName)
@@ -134,11 +87,6 @@ func (npdo *NodeProblemDetectorOptions) AddFlags(fs *pflag.FlagSet) {
 
 // ValidOrDie validates node problem detector command line options.
 func (npdo *NodeProblemDetectorOptions) ValidOrDie() {
-	if _, err := url.Parse(npdo.ApiServerOverride); npdo.EnableK8sExporter && err != nil {
-		panic(fmt.Sprintf("apiserver-override %q is not a valid HTTP URI: %v",
-			npdo.ApiServerOverride, err))
-	}
-
 	if len(npdo.SystemLogMonitorConfigPaths) != 0 {
 		panic("SystemLogMonitorConfigPaths is deprecated. It should have been reassigned to MonitorConfigPaths. This should not happen.")
 	}

--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"os"
 	"reflect"
 	"testing"
 
@@ -55,68 +54,6 @@ func equalMonitorConfigPaths(npdoX NodeProblemDetectorOptions, npdoY NodeProblem
 		}
 	}
 	return true
-}
-
-type options struct {
-	Nodename         string
-	HostnameOverride string
-}
-
-// TestSetNodeNameOrDie tests for permutations of nodename, hostname and hostnameoverride.
-func TestSetNodeNameOrDie(t *testing.T) {
-	hostName, err := os.Hostname()
-	if err != nil {
-		t.Errorf("Query hostname error: %v", err)
-	}
-
-	uts := map[string]struct {
-		WantedNodeName string
-		Meta           options
-	}{
-		"Check hostname override only": {
-			WantedNodeName: "hostname-override",
-			Meta: options{
-				Nodename:         "node-name-env",
-				HostnameOverride: "hostname-override",
-			},
-		},
-		"Check hostname override and NODE_NAME env": {
-			WantedNodeName: "node-name-env",
-			Meta: options{
-				Nodename:         "node-name-env",
-				HostnameOverride: "",
-			},
-		},
-		"Check hostname override, NODE_NAME env and hostname": {
-			WantedNodeName: hostName,
-			Meta: options{
-				Nodename:         "",
-				HostnameOverride: "",
-			},
-		},
-	}
-
-	for desc, ut := range uts {
-		err := os.Unsetenv("NODE_NAME")
-		if err != nil {
-			t.Errorf("Desc: %v. Unset NODE_NAME env error: %v", desc, err)
-		}
-
-		if len(ut.Meta.Nodename) != 0 {
-			err := os.Setenv("NODE_NAME", ut.Meta.Nodename)
-			if err != nil {
-				t.Errorf("Desc: %v. Set NODE_NAME env error: %v", desc, err)
-			}
-		}
-
-		npdOpts := NewNodeProblemDetectorOptions()
-		npdOpts.HostnameOverride = ut.Meta.HostnameOverride
-		npdOpts.SetNodeNameOrDie()
-
-		if npdOpts.NodeName != ut.WantedNodeName {
-			t.Errorf("Desc: %v. Set node name error. Wanted: %v. Got: %v", desc, ut.WantedNodeName, npdOpts.NodeName)
-		}
-	}
 }
 
 func TestValidOrDie(t *testing.T) {

--- a/cmd/options/options_test.go
+++ b/cmd/options/options_test.go
@@ -68,40 +68,6 @@ func TestValidOrDie(t *testing.T) {
 		expectPanic bool
 	}{
 		{
-			name: "default k8s exporter config",
-			npdo: NodeProblemDetectorOptions{
-				MonitorConfigPaths: fooMonitorConfigMap,
-			},
-			expectPanic: false,
-		},
-		{
-			name: "enables k8s exporter config",
-			npdo: NodeProblemDetectorOptions{
-				ApiServerOverride:  "",
-				EnableK8sExporter:  true,
-				MonitorConfigPaths: fooMonitorConfigMap,
-			},
-			expectPanic: false,
-		},
-		{
-			name: "k8s exporter config with valid ApiServerOverride",
-			npdo: NodeProblemDetectorOptions{
-				ApiServerOverride:  "127.0.0.1",
-				EnableK8sExporter:  true,
-				MonitorConfigPaths: fooMonitorConfigMap,
-			},
-			expectPanic: false,
-		},
-		{
-			name: "k8s exporter config with invalid ApiServerOverride",
-			npdo: NodeProblemDetectorOptions{
-				ApiServerOverride:  ":foo",
-				EnableK8sExporter:  true,
-				MonitorConfigPaths: fooMonitorConfigMap,
-			},
-			expectPanic: true,
-		},
-		{
 			name: "non-empty MonitorConfigPaths",
 			npdo: NodeProblemDetectorOptions{
 				MonitorConfigPaths: fooMonitorConfigMap,

--- a/pkg/exporters/k8sexporter/options/options.go
+++ b/pkg/exporters/k8sexporter/options/options.go
@@ -1,0 +1,47 @@
+package options
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+type CommandLineOptions struct {
+	// EnableK8sExporter is the flag determining whether to report to Kubernetes.
+	EnableK8sExporter bool
+	// HostnameOverride specifies custom node name used to override hostname.
+	HostnameOverride string
+	// ApiServerOverride is the custom URI used to connect to Kubernetes ApiServer.
+	ApiServerOverride string
+	// APIServerWaitTimeout is the timeout on waiting for kube-apiserver to be
+	// ready.
+	APIServerWaitTimeout time.Duration
+	// APIServerWaitInterval is the interval between the checks on the
+	// readiness of kube-apiserver.
+	APIServerWaitInterval time.Duration
+	// K8sExporterHeartbeatPeriod is the period at which the k8s exporter does forcibly sync with apiserver.
+	K8sExporterHeartbeatPeriod time.Duration
+	// ServerPort is the port to bind the node problem detector server. Use 0 to disable.
+	ServerPort int
+	// ServerAddress is the address to bind the node problem detector server.
+	ServerAddress string
+}
+
+func (o *CommandLineOptions) SetFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.EnableK8sExporter, "enable-k8s-exporter", true,
+		"Enables reporting to Kubernetes API server.")
+	fs.StringVar(&o.ApiServerOverride, "apiserver-override", "",
+		"Custom URI used to connect to Kubernetes ApiServer. This is ignored if --enable-k8s-exporter is false.")
+	fs.DurationVar(&o.APIServerWaitTimeout, "apiserver-wait-timeout", time.Duration(5)*time.Minute,
+		"The timeout on waiting for kube-apiserver to be ready. This is ignored if --enable-k8s-exporter is false.")
+	fs.DurationVar(&o.APIServerWaitInterval, "apiserver-wait-interval", time.Duration(5)*time.Second,
+		"The interval between the checks on the readiness of kube-apiserver. This is ignored if --enable-k8s-exporter is false.")
+	fs.DurationVar(&o.K8sExporterHeartbeatPeriod, "k8s-exporter-heartbeat-period", time.Duration(5)*time.Minute,
+		"The period at which k8s-exporter does forcibly sync with apiserver.")
+	fs.StringVar(&o.HostnameOverride, "hostname-override", "",
+		"Custom node name used to override hostname")
+	fs.IntVar(&o.ServerPort, "port", 20256,
+		"The port to bind the node problem detector server. Use 0 to disable.")
+	fs.StringVar(&o.ServerAddress, "address", "127.0.0.1",
+		"The address to bind the node problem detector server.")
+}

--- a/pkg/exporters/k8sexporter/problemclient/problem_client_test.go
+++ b/pkg/exporters/k8sexporter/problemclient/problem_client_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/node-problem-detector/cmd/options"
+	"k8s.io/node-problem-detector/pkg/exporters/k8sexporter/options"
 )
 
 const (
@@ -137,11 +137,10 @@ func TestSetNodeNameOrDie(t *testing.T) {
 				}
 			}
 
-			npdOpts := options.NewNodeProblemDetectorOptions()
-			npdOpts.HostnameOverride = test.hostNameOverride
+			k8sOptions := options.CommandLineOptions{HostnameOverride: test.hostNameOverride}
 
 			client := nodeProblemClient{}
-			client.setNodeNameOrDie(npdOpts)
+			client.setNodeNameOrDie(&k8sOptions)
 
 			if client.nodeName != test.wantedNodeName {
 				t.Errorf("Set node name error. Wanted: %v. Got: %v", test.wantedNodeName, client.nodeName)


### PR DESCRIPTION
This is for #345 

A little background:
We want to make all problem daemons (system-log, system-stats, custom-plugin) and all exporters (k8s, prometheus, stackdriver) into "plugins". By "plugin", what I really mean is this:

1. NPD main code does not directly import these libraries, and does not use these libraries directly.

1. Each plugin should be able to be disabled at compile time.

The challenge comes from the existing exporters (k8s, prometheus). They have been existing for a while, and is configured via command-line flags (e.g. `--apiserver-override`, `--apiserver-wait-timeout`). So to refactor them into plugins, we had to allow plugins to define their own command-line options.

We have already implemented mechanism to allow plugins to define their own command-line interfaces in #335. This PR is to pick it up for the existing exporters (k8s and prometheus).