### PR TITLE
Allow e2e test to pick up test VM image using image family

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ e2e-test: vet fmt build-tar
 	GO111MODULE=on go test -mod vendor -timeout=10m -v $(BUILD_TAGS) \
 	./test/e2e/metriconly/... \
 	-project=$(PROJECT) -zone=$(ZONE) \
-	-image=$(VM_IMAGE) -image-project=$(IMAGE_PROJECT) \
+	-image=$(VM_IMAGE) -image-family=$(IMAGE_FAMILY) -image-project=$(IMAGE_PROJECT) \
 	-ssh-user=$(SSH_USER) -ssh-key=$(SSH_KEY) \
 	-npd-build-tar=`pwd`/$(TARBALL) \
 	-boskos-project-type=$(BOSKOS_PROJECT_TYPE) -job-name=$(JOB_NAME) \

--- a/test/e2e/metriconly/e2e_npd_test.go
+++ b/test/e2e/metriconly/e2e_npd_test.go
@@ -38,6 +38,7 @@ const junitFileName = "junit.xml"
 var zone = flag.String("zone", "", "gce zone the hosts live in")
 var project = flag.String("project", "", "gce project the hosts live in")
 var image = flag.String("image", "", "image to test")
+var imageFamily = flag.String("image-family", "", "image family to pick up the test image. Ignored when -image is set.")
 var imageProject = flag.String("image-project", "", "gce project of the OS image")
 var jobName = flag.String("job-name", "", "name of the Prow job running the test")
 var sshKey = flag.String("ssh-key", "", "path to ssh private key.")

--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -37,6 +37,15 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		var err error
 		// TODO(xueweiz): Creating instance for each test case is slow. We should either reuse the instance
 		// between tests, or have a way to run these tests in parallel.
+		if *imageFamily != "" && *image == "" {
+			gceImage, err := computeService.Images.GetFromFamily(*imageProject, *imageFamily).Do()
+			if err != nil {
+				ginkgo.Fail(fmt.Sprintf("Unable to get image from family %s at project %s: %v",
+					*imageFamily, *imageProject, err))
+			}
+			*image = gceImage.Name
+			fmt.Printf("Using image %s from image family %s at project %s\n", *image, *imageFamily, *imageProject)
+		}
 		instance, err = gce.CreateInstance(
 			gce.Instance{
 				Name:           "npd-metrics-" + *image + "-" + uuid.NewUUID().String()[:8],


### PR DESCRIPTION
Currently the Prow job config is hard-coded to pick up test image by image name: https://github.com/kubernetes/test-infra/blob/1a958b0c2b6ddbb813bf6d23fe6b5714e9812e38/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml#L269

We should change it so that the test pick up test image by image family, so that it will keep testing on the latest stable (product quality) images.

This change is tested locally via:
```
ZONE=us-central1-a PROJECT=xueweiz-experimental IMAGE_FAMILY=cos-73-lts IMAGE_PROJECT=cos-cloud SSH_USER=${USER} SSH_KEY=~/.ssh/id_rsa make e2e-test
```

I will soon setup the Prow job so that it pick up test image by image family, and this code path will be tested continuously.