### PR TITLE
Make heartbeatPeriod const into a flag

### DIFF
--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -57,6 +57,8 @@ type NodeProblemDetectorOptions struct {
 	// APIServerWaitInterval is the interval between the checks on the
 	// readiness of kube-apiserver.
 	APIServerWaitInterval time.Duration
+	// K8sExporterHeartbeatPeriod is the period at which the k8s exporter does forcibly sync with apiserver.
+	K8sExporterHeartbeatPeriod time.Duration
 
 	// prometheusExporter options
 	// PrometheusServerPort is the port to bind the Prometheus scrape endpoint. Use 0 to disable.
@@ -107,6 +109,7 @@ func (npdo *NodeProblemDetectorOptions) AddFlags(fs *pflag.FlagSet) {
 		"", "Custom URI used to connect to Kubernetes ApiServer. This is ignored if --enable-k8s-exporter is false.")
 	fs.DurationVar(&npdo.APIServerWaitTimeout, "apiserver-wait-timeout", time.Duration(5)*time.Minute, "The timeout on waiting for kube-apiserver to be ready. This is ignored if --enable-k8s-exporter is false.")
 	fs.DurationVar(&npdo.APIServerWaitInterval, "apiserver-wait-interval", time.Duration(5)*time.Second, "The interval between the checks on the readiness of kube-apiserver. This is ignored if --enable-k8s-exporter is false.")
+	fs.DurationVar(&npdo.K8sExporterHeartbeatPeriod, "k8s-exporter-heartbeat-period", 1*time.Minute, "The period at which k8s-exporter does forcibly sync with apiserver.")
 	fs.BoolVar(&npdo.PrintVersion, "version", false, "Print version information and quit")
 	fs.StringVar(&npdo.HostnameOverride, "hostname-override",
 		"", "Custom node name used to override hostname")

--- a/pkg/exporters/k8sexporter/condition/manager_test.go
+++ b/pkg/exporters/k8sexporter/condition/manager_test.go
@@ -31,10 +31,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 )
 
+const heartbeatPeriod = 1 * time.Minute
+
 func newTestManager() (*conditionManager, *problemclient.FakeProblemClient, *clock.FakeClock) {
 	fakeClient := problemclient.NewFakeProblemClient()
 	fakeClock := clock.NewFakeClock(time.Now())
-	manager := NewConditionManager(fakeClient, fakeClock)
+	manager := NewConditionManager(fakeClient, fakeClock, heartbeatPeriod)
 	return manager.(*conditionManager), fakeClient, fakeClock
 }
 

--- a/pkg/exporters/k8sexporter/k8s_exporter.go
+++ b/pkg/exporters/k8sexporter/k8s_exporter.go
@@ -58,7 +58,7 @@ func NewExporterOrDie(npdo *options.NodeProblemDetectorOptions) types.Exporter {
 
 	ke := k8sExporter{
 		client:           c,
-		conditionManager: condition.NewConditionManager(c, clock.RealClock{}),
+		conditionManager: condition.NewConditionManager(c, clock.RealClock{}, npdo.K8sExporterHeartbeatPeriod),
 	}
 
 	ke.startHTTPReporting(npdo)


### PR DESCRIPTION
This is an important parameter when it comes to kubernetes scalability (it controlls the node/status patch QPS) and it deserves to be a flag instead of a constant. 

/sig scalability