### PR TITLE
Update node-problem-detector-config

### DIFF
--- a/deployment/node-problem-detector-config.yaml
+++ b/deployment/node-problem-detector-config.yaml
@@ -15,8 +15,8 @@ data:
             },
             {
                 "type": "ReadonlyFilesystem",
-                "reason": "FilesystemIsReadOnly",
-                "message": "Filesystem is read-only"
+                "reason": "FilesystemIsNotReadOnly",
+                "message": "Filesystem is not read-only"
             }
         ],
         "rules": [


### PR DESCRIPTION
Seems there is an inconsistency between [/config](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json) and [/deployment](https://github.com/kubernetes/node-problem-detector/blob/master/deployment/node-problem-detector-config.yaml) examples for kernel-monitor. 
Updating deployment example accordingly.