### PR TITLE
Properly close channel when monitors exit.

### DIFF
--- a/cmd/logcounter/log_counter.go
+++ b/cmd/logcounter/log_counter.go
@@ -44,7 +44,11 @@ func main() {
 		fmt.Print(err)
 		os.Exit(int(types.Unknown))
 	}
-	actual := counter.Count()
+	actual, err := counter.Count()
+	if err != nil {
+		fmt.Print(err)
+		os.Exit(int(types.Unknown))
+	}
 	if actual >= fedo.Count {
 		fmt.Printf("Found %d matching logs, which meets the threshold of %d\n", actual, fedo.Count)
 		os.Exit(int(types.NonOK))

--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -128,7 +128,11 @@ func (c *customPluginMonitor) monitorLoop() {
 
 	for {
 		select {
-		case result := <-resultChan:
+		case result, ok := <-resultChan:
+			if !ok {
+				glog.Errorf("Result channel closed: %s", c.configPath)
+				return
+			}
 			glog.V(3).Infof("Receive new plugin result for %s: %+v", c.configPath, result)
 			status := c.generateStatus(result)
 			glog.Infof("New status generated: %+v", status)

--- a/pkg/custompluginmonitor/plugin/plugin.go
+++ b/pkg/custompluginmonitor/plugin/plugin.go
@@ -55,6 +55,7 @@ func (p *Plugin) GetResultChan() <-chan cpmtypes.Result {
 func (p *Plugin) Run() {
 	defer func() {
 		glog.Info("Stopping plugin execution")
+		close(p.resultChan)
 		p.tomb.Done()
 	}()
 

--- a/pkg/logcounter/log_counter.go
+++ b/pkg/logcounter/log_counter.go
@@ -63,11 +63,15 @@ func NewJournaldLogCounter(options *options.LogCounterOptions) (types.LogCounter
 	}, nil
 }
 
-func (e *logCounter) Count() (count int) {
+func (e *logCounter) Count() (count int, err error) {
 	start := e.clock.Now()
 	for {
 		select {
-		case log := <-e.logCh:
+		case log, ok := <-e.logCh:
+			if !ok {
+				err = fmt.Errorf("log channel closed unexpectedly")
+				return
+			}
 			// We only want to count events up until the time at which we started.
 			// Otherwise we would run forever
 			if start.Before(log.Timestamp) {

--- a/pkg/logcounter/log_counter_test.go
+++ b/pkg/logcounter/log_counter_test.go
@@ -120,7 +120,10 @@ func TestCount(t *testing.T) {
 					fakeClock.Step(2 * timeout)
 				}
 			}(tc.logs, logCh)
-			actualCount := counter.Count()
+			actualCount, err := counter.Count()
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
 			if actualCount != tc.expectedCount {
 				t.Errorf("got %d; expected %d", actualCount, tc.expectedCount)
 			}

--- a/pkg/logcounter/types/types.go
+++ b/pkg/logcounter/types/types.go
@@ -17,5 +17,5 @@ limitations under the License.
 package types
 
 type LogCounter interface {
-	Count() int
+	Count() (int, error)
 }

--- a/pkg/systemlogmonitor/log_monitor.go
+++ b/pkg/systemlogmonitor/log_monitor.go
@@ -125,13 +125,16 @@ func (l *logMonitor) Stop() {
 
 // monitorLoop is the main loop of log monitor.
 func (l *logMonitor) monitorLoop() {
-	defer l.tomb.Done()
+	defer func() {
+		close(l.output)
+		l.tomb.Done()
+	}()
 	l.initializeStatus()
 	for {
 		select {
 		case log, ok := <-l.logCh:
 			if !ok {
-				glog.Errorf("Log channel closed")
+				glog.Errorf("Log channel closed: %s", l.configPath)
 				return
 			}
 			l.parseLog(log)

--- a/test/e2e/lib/gce/instance.go
+++ b/test/e2e/lib/gce/instance.go
@@ -46,7 +46,7 @@ func CreateInstance(instance Instance, imageName string, imageProject string) (I
 
 	p, err := instance.ComputeService.Projects.Get(instance.Project).Do()
 	if err != nil {
-		return instance, fmt.Errorf("failed to get project info %q", instance.Project)
+		return instance, fmt.Errorf("failed to get project info %q: %v", instance.Project, err)
 	}
 
 	i := &compute.Instance{


### PR DESCRIPTION
This is a follow up of https://github.com/kubernetes/node-problem-detector/pull/339.
Will rebase after https://github.com/kubernetes/node-problem-detector/pull/339 is merged.

This PR:
1) Handles channel close for log counter, or else we may get nil log entry and cause a panic;
2) Handles channel close for kmsg parser, or else we may have another busy loop;
3) Handles channel close for custom plugin monitor, this is less an issue because the plugin will never close its channel, but let's add this for completion;
4) Closes channels returned to the problem detector, so that the goroutine in the problem detector can exit if the corresponding problem daemon exits.

1 and 2 are a more important bug fix that we may want to cherry-pick, 3 and 4 are not that important.

Signed-off-by: Lantao Liu <lantaol@google.com>