### PR TITLE
Fix build tags manipulation in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ script:
  - BUILD_TAGS="disable_system_stats_monitor" make test
  - make clean && BUILD_TAGS="disable_stackdriver_exporter" make
  - BUILD_TAGS="disable_stackdriver_exporter" make test
+ - make clean && ENABLE_JOURNALD=0 make
+ - ENABLE_JOURNALD=0 make test

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -21,6 +21,9 @@ RUN clean-install libsystemd0 bash
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true
 
 ADD ./bin/node-problem-detector /node-problem-detector
+
+# Below command depends on ENABLE_JOURNAL=1.
 ADD ./bin/log-counter /home/kubernetes/bin/log-counter
+
 ADD config /config
 ENTRYPOINT ["/node-problem-detector", "--system-log-monitors=/config/kernel-monitor.json"]

--- a/cmd/logcounter/log_counter.go
+++ b/cmd/logcounter/log_counter.go
@@ -1,3 +1,5 @@
+// +build journald
+
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.
 

--- a/pkg/logcounter/log_counter.go
+++ b/pkg/logcounter/log_counter.go
@@ -1,3 +1,5 @@
+// +build journald
+
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.
 

--- a/pkg/logcounter/log_counter_test.go
+++ b/pkg/logcounter/log_counter_test.go
@@ -1,3 +1,5 @@
+// +build journald
+
 /*
 Copyright 2018 The Kubernetes Authors All rights reserved.
 


### PR DESCRIPTION
This is for #366 

In the current Makefile, when ENABLE_JOURNAL is set to 0, BUILD_TAGS will be set to `""`. And result in below command:
```
CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build \
		-mod vendor \
		-o bin/node-problem-detector \
		-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.7.1-20-gc55fa33' \
		"" \
		./cmd/nodeproblemdetector
```

The `""` confuses golang into compiling the current directory :) which then causes the problem:
```
can't load package: package k8s.io/node-problem-detector: no Go files in /Users/mgrosser/Code/tools/node-problem-detector
make: *** [bin/node-problem-detector] Error 1
```

Also added a test case for the `ENABLE_JOURNAL=0` use case.

Also fixed a few rules for `log-counter` to deal with `ENABLE_JOURNAL=0`:
`log-counter` currently [only supports journald](https://github.com/kubernetes/node-problem-detector/blob/ef30a1fdd173198d1ce6475d6ed1f698759cee72/cmd/logcounter/log_counter.go#L42). So when `ENABLE_JOURNAL=0` is specified, the binary won't compile, and `docker build` won't find the binary to be installed into the docker image.

The fix basically skips the compilation and installation for `log-counter` when `ENABLE_JOURNAL=0`.
The change does not has any effect when `ENABLE_JOURNAL=1`.