### PR TITLE
Improve systemctl check, style + cleanup

### DIFF
--- a/config/plugin/check_ntp.sh
+++ b/config/plugin/check_ntp.sh
@@ -1,23 +1,27 @@
 #!/bin/bash
 
-# NOTE: THIS NTP SERVICE CHECK SCRIPT ASSUME THAT NTP SERVICE IS RUNNING UNDER SYSTEMD.
-#       THIS IS JUST AN EXAMPLE. YOU CAN WRITE YOUR OWN NODE PROBLEM PLUGIN ON DEMAND.
+# This plugin checks if the ntp service is running under systemd.
+# NOTE: This is only an example for systemd services.
 
-OK=0
-NONOK=1
-UNKNOWN=2
+readonly OK=0
+readonly NONOK=1
+readonly UNKNOWN=2
 
-which systemctl >/dev/null
-if [ $? -ne 0 ]; then
-    echo "Systemd is not supported"
-    exit $UNKNOWN
+readonly SERVICE='ntp.service'
+
+# Check systemd cmd present
+if ! command -v systemctl >/dev/null; then
+  echo "Could not find 'systemctl' - require systemd"
+  exit $UNKNOWN
 fi
 
-systemctl status ntp.service | grep 'Active:' | grep -q running
-if [ $? -ne 0 ]; then
-    echo "NTP service is not running"
-    exit $NONOK
+# Return success if service active (i.e. running)
+if systemctl -q is-active "$SERVICE"; then
+  echo "$SERVICE is running"
+  exit $OK
+else
+  # Does not differenciate stopped/failed service from non-existent
+  echo "$SERVICE is not running"
+  exit $NONOK
 fi
 
-echo "NTP service is running"
-exit $OK


### PR DESCRIPTION
- Use `systemctl is-active` to check if service is running
  - Cleaner that `grep` on `systemctl status` output
  - Return success means service is running/active
  - Return failure means not running which could be due to
    stopped/failed service or that service does not exist

- Use `command -v` instead of `which`
  Ref: https://github.com/koalaman/shellcheck/wiki/SC2230

- Follow Google "Shell Style Guide": indent, use "readonly"

- Minor: Rephrase comment, avoid all caps