### PR TITLE
fix make test early failure

### DIFF
--- a/test/e2e/metriconly/e2e_npd_test.go
+++ b/test/e2e/metriconly/e2e_npd_test.go
@@ -59,6 +59,12 @@ func TestNPD(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
+	var err error
+	computeService, err = gce.GetComputeClient()
+	if err != nil {
+		panic(fmt.Sprintf("Unable to create gcloud compute service using defaults. Make sure you are authenticated. %v", err))
+	}
+
 	if *project == "" {
 		boskosClient := client.NewClient(*jobName, *boskosServerURL)
 		*project = acquireProjectOrDie(boskosClient)
@@ -111,12 +117,6 @@ func releaseProjectOrDie(boskosClient *client.Client) {
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-
-	var err error
-	computeService, err = gce.GetComputeClient()
-	if err != nil {
-		panic(fmt.Sprintf("Unable to create gcloud compute service using defaults. Make sure you are authenticated. %v", err))
-	}
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
### Motivation:
`make test` would fail right now because `TestMain()` in `test/e2e/metriconly/e2e_npd_test.go` is attempting to create gcloud compute service. See the error reported below by running `make test`:
![image](https://user-images.githubusercontent.com/9733465/69894460-ebffd480-12d4-11ea-8099-95e48e40b78c.png)


### Changes:
This check should be moved into `TestNPD(t *testing.T)`, where this test can be skipped according to `make test rule`:

```makefile
 test: vet fmt
	GO111MODULE=on go test -mod vendor -timeout=1m -v -race -short -tags "$(BUILD_TAGS)" ./...
```

### Test Plan:
- `make test` should pass