### PR TITLE
Using time.Since(t) instead of t.Sub(time.Now())

### DIFF
--- a/pkg/custompluginmonitor/plugin/plugin.go
+++ b/pkg/custompluginmonitor/plugin/plugin.go
@@ -96,9 +96,8 @@ func (p *Plugin) runRules() {
 
 			start := time.Now()
 			exitStatus, message := p.run(*rule)
-			end := time.Now()
 
-			glog.V(3).Infof("Rule: %+v. Start time: %v. End time: %v. Duration: %v", rule, start, end, end.Sub(start))
+			glog.V(3).Infof("Rule: %+v. Start time: %v. End time: %v. Duration: %v", rule, start, time.Now(), time.Since(start))
 
 			result := cpmtypes.Result{
 				Rule:       rule,

--- a/pkg/exporters/k8sexporter/condition/manager.go
+++ b/pkg/exporters/k8sexporter/condition/manager.go
@@ -141,12 +141,12 @@ func (c *conditionManager) needUpdates() bool {
 // needResync checks whether a resync is needed.
 func (c *conditionManager) needResync() bool {
 	// Only update when resync is needed.
-	return c.clock.Now().Sub(c.latestTry) >= resyncPeriod && c.resyncNeeded
+	return c.clock.Since(c.latestTry) >= resyncPeriod && c.resyncNeeded
 }
 
 // needHeartbeat checks whether a forcible heartbeat is needed.
 func (c *conditionManager) needHeartbeat() bool {
-	return c.clock.Now().Sub(c.latestTry) >= c.heartbeatPeriod
+	return c.clock.Since(c.latestTry) >= c.heartbeatPeriod
 }
 
 // sync synchronizes node conditions with the apiserver.


### PR DESCRIPTION
Using time.Since(t) instead of t.Sub(time.Now())