### PR TITLE
Rename problem metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ VERSION?=$(shell if [ -d .git ]; then echo `git describe --tags --dirty`; else e
 # TAG is the tag of the container image, default to binary version.
 TAG?=$(VERSION)
 
+# GO points to the target go compilor, allowing cross-compilation.
+GO?=go
+
 # REGISTRY is the container registry to push into.
 REGISTRY?=staging-k8s.gcr.io
 
@@ -76,9 +79,9 @@ ifeq ($(ENABLE_JOURNALD), 1)
 endif
 
 vet:
-	GO111MODULE=on go list -mod vendor -tags "$(BUILD_TAGS)" ./... | \
+	GO111MODULE=on "$(GO)" list -mod vendor -tags "$(BUILD_TAGS)" ./... | \
 		grep -v "./vendor/*" | \
-		GO111MODULE=on xargs go vet -mod vendor -tags "$(BUILD_TAGS)"
+		GO111MODULE=on xargs "$(GO)" vet -mod vendor -tags "$(BUILD_TAGS)"
 
 fmt:
 	find . -type f -name "*.go" | grep -v "./vendor/*" | xargs gofmt -s -w -l
@@ -88,7 +91,7 @@ version:
 
 ./bin/log-counter: $(PKG_SOURCES)
 ifeq ($(ENABLE_JOURNALD), 1)
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GO111MODULE=on go build \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GO111MODULE=on "$(GO)" build \
 		-mod vendor \
 		-o bin/log-counter \
 		-ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
@@ -99,7 +102,7 @@ else
 endif
 
 ./bin/node-problem-detector: $(PKG_SOURCES)
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GO111MODULE=on go build \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GO111MODULE=on "$(GO)" build \
 		-mod vendor \
 		-o bin/node-problem-detector \
 		-ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
@@ -107,7 +110,7 @@ endif
 		./cmd/nodeproblemdetector
 
 ./test/bin/problem-maker: $(PKG_SOURCES)
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GO111MODULE=on go build \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GO111MODULE=on "$(GO)" build \
 		-mod vendor \
 		-o test/bin/problem-maker \
 		-tags "$(BUILD_TAGS)" \
@@ -122,7 +125,7 @@ endif
 
 
 test: vet fmt
-	GO111MODULE=on go test -mod vendor -timeout=1m -v -race -short -tags "$(BUILD_TAGS)" ./...
+	GO111MODULE=on "$(GO)" test -mod vendor -timeout=1m -v -race -short -tags "$(BUILD_TAGS)" ./...
 
 e2e-test: vet fmt build-tar
 	GO111MODULE=on ginkgo -nodes=$(PARALLEL) -mod vendor -timeout=10m -v -tags "$(BUILD_TAGS)" -stream \

--- a/pkg/problemmetrics/problem_metrics.go
+++ b/pkg/problemmetrics/problem_metrics.go
@@ -56,7 +56,7 @@ func NewProblemMetricsManagerOrDie() *ProblemMetricsManager {
 		metrics.Sum,
 		[]string{"reason"})
 	if err != nil {
-		glog.Fatalf("Failed to create problem_counter metric: %v", err)
+		glog.Fatalf("Failed to create %q metric: %v", metrics.ProblemCounterID, err)
 	}
 
 	pmm.problemGauge, err = metrics.NewInt64Metric(
@@ -67,7 +67,7 @@ func NewProblemMetricsManagerOrDie() *ProblemMetricsManager {
 		metrics.LastValue,
 		[]string{"type", "reason"})
 	if err != nil {
-		glog.Fatalf("Failed to create problem_gauge metric: %v", err)
+		glog.Fatalf("Failed to create %q metric: %v", metrics.ProblemGaugeID, err)
 	}
 
 	pmm.problemTypeToReason = make(map[string]string)

--- a/pkg/problemmetrics/problem_metrics_stub.go
+++ b/pkg/problemmetrics/problem_metrics_stub.go
@@ -23,8 +23,8 @@ import (
 // NewProblemMetricsManagerStub creates a ProblemMetricsManager stubbed by fake metrics.
 // The stubbed ProblemMetricsManager and fake metrics are returned.
 func NewProblemMetricsManagerStub() (*ProblemMetricsManager, *metrics.FakeInt64Metric, *metrics.FakeInt64Metric) {
-	fakeProblemCounter := metrics.NewFakeInt64Metric("problem_counter", metrics.Sum, []string{"reason"})
-	fakeProblemGauge := metrics.NewFakeInt64Metric("problem_gauge", metrics.LastValue, []string{"type", "reason"})
+	fakeProblemCounter := metrics.NewFakeInt64Metric(string(metrics.ProblemCounterID), metrics.Sum, []string{"reason"})
+	fakeProblemGauge := metrics.NewFakeInt64Metric(string(metrics.ProblemGaugeID), metrics.LastValue, []string{"type", "reason"})
 
 	pmm := ProblemMetricsManager{}
 	pmm.problemCounter = metrics.Int64MetricInterface(fakeProblemCounter)

--- a/pkg/problemmetrics/problem_metrics_test.go
+++ b/pkg/problemmetrics/problem_metrics_test.go
@@ -43,7 +43,7 @@ func TestNewProblem(t *testing.T) {
 			counts:  []int64{1},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "foo"},
 					Value:  1,
 				},
@@ -55,7 +55,7 @@ func TestNewProblem(t *testing.T) {
 			counts:  []int64{1, 1},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "foo"},
 					Value:  2,
 				},
@@ -67,12 +67,12 @@ func TestNewProblem(t *testing.T) {
 			counts:  []int64{1, 1, 1},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "foo"},
 					Value:  2,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "bar"},
 					Value:  1,
 				},
@@ -84,12 +84,12 @@ func TestNewProblem(t *testing.T) {
 			counts:  []int64{0, 0},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "bar"},
 					Value:  0,
 				},
@@ -101,12 +101,12 @@ func TestNewProblem(t *testing.T) {
 			counts:  []int64{0, 0, 1, 1, 1},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "foo"},
 					Value:  2,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "bar"},
 					Value:  1,
 				},
@@ -152,7 +152,7 @@ func TestSetProblemGauge(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonFoo"},
 					Value:  1,
 				},
@@ -166,7 +166,7 @@ func TestSetProblemGauge(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonFoo"},
 					Value:  1,
 				},
@@ -180,12 +180,12 @@ func TestSetProblemGauge(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonFoo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonBar"},
 					Value:  1,
 				},
@@ -199,12 +199,12 @@ func TestSetProblemGauge(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": ""},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonFoo"},
 					Value:  0,
 				},
@@ -219,17 +219,17 @@ func TestSetProblemGauge(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": ""},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonFoo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonBar"},
 					Value:  1,
 				},
@@ -244,17 +244,17 @@ func TestSetProblemGauge(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": ""},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeA", "reason": "ReasonFoo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ProblemTypeB", "reason": "ReasonBar"},
 					Value:  1,
 				},

--- a/pkg/systemlogmonitor/README.md
+++ b/pkg/systemlogmonitor/README.md
@@ -96,20 +96,19 @@ default.
 Temporary problems will be reported as counter metrics, such as below example:
 
 ```
-# HELP problem_counter Number of times a specific type of problem have occurred.
-# TYPE problem_counter counter
-problem_counter{reason="TaskHung"} 2
+# HELP problem_count_total Number of times a specific type of problem have occurred.
+# TYPE problem_count_total counter
+problem_count_total{reason="TaskHung"} 2
 ```
 
 Permanent problems will be reported as both gauge metrics and counter metrics, such as below
 example:
 
 ```
-# HELP problem_counter Number of times a specific type of problem have occurred.
-# TYPE problem_counter counter
-problem_counter{reason="DockerHung"} 1
-# HELP problem_gauge Whether a specific type of problem is affecting the node or not.
-# TYPE problem_gauge gauge
-problem_gauge{condition="KernelDeadlock",reason="DockerHung"} 1
+# HELP problem_count_total Number of times a specific type of problem have occurred.
+# TYPE problem_count_total counter
+problem_count_total{reason="DockerHung"} 1
+# HELP problem_state Whether a specific type of problem is affecting the node or not.
+# TYPE problem_state gauge
+problem_state{type="KernelDeadlock",reason="DockerHung"} 1
 ```
-

--- a/pkg/systemlogmonitor/log_monitor_test.go
+++ b/pkg/systemlogmonitor/log_monitor_test.go
@@ -175,7 +175,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  1,
 				},
@@ -196,7 +196,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  2,
 				},
@@ -217,12 +217,12 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason bar"},
 					Value:  1,
 				},
@@ -245,12 +245,12 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  1,
 				},
@@ -278,12 +278,12 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  1,
 				},
@@ -311,22 +311,22 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason bar"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason bar"},
 					Value:  1,
 				},
@@ -358,22 +358,22 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionB", "reason": "problem reason bar"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  1,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason bar"},
 					Value:  1,
 				},
@@ -427,7 +427,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
@@ -444,12 +444,12 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
@@ -469,7 +469,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
@@ -489,12 +489,12 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason bar"},
 					Value:  0,
 				},
@@ -516,22 +516,22 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason bar"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason bar"},
 					Value:  0,
 				},
@@ -553,22 +553,22 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionB", "reason": "problem reason bar"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason bar"},
 					Value:  0,
 				},
@@ -590,12 +590,12 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
@@ -639,37 +639,37 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 			},
 			expectedMetrics: []metrics.Int64MetricRepresentation{
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason hello"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionA", "reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionB", "reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_gauge",
+					Name:   "problem_state",
 					Labels: map[string]string{"type": "ConditionB", "reason": "problem reason bar"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason hello"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason foo"},
 					Value:  0,
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "problem reason bar"},
 					Value:  0,
 				},

--- a/pkg/util/metrics/helpers_test.go
+++ b/pkg/util/metrics/helpers_test.go
@@ -80,11 +80,11 @@ func TestPrometheusMetricsParsingAndMatching(t *testing.T) {
 					Labels: map[string]string{"kernel_version": "4.14.127+", "os_version": "cos 73-11647.217.0"},
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "DockerHung"},
 				},
 				{
-					Name:   "problem_counter",
+					Name:   "problem_count_total",
 					Labels: map[string]string{"reason": "OOMKilling"},
 				},
 			},

--- a/pkg/util/metrics/metric.go
+++ b/pkg/util/metrics/metric.go
@@ -22,8 +22,8 @@ import (
 const (
 	CPURunnableTaskCountID  MetricID = "cpu/runnable_task_count"
 	CPUUsageTimeID          MetricID = "cpu/usage_time"
-	ProblemCounterID        MetricID = "problem_counter"
-	ProblemGaugeID          MetricID = "problem_gauge"
+	ProblemCounterID        MetricID = "problem_count_total"
+	ProblemGaugeID          MetricID = "problem_state"
 	DiskIOTimeID            MetricID = "disk/io_time"
 	DiskWeightedIOID        MetricID = "disk/weighted_io"
 	DiskAvgQueueLenID       MetricID = "disk/avg_queue_len"

--- a/pkg/util/metrics/testdata/sample_metrics.txt
+++ b/pkg/util/metrics/testdata/sample_metrics.txt
@@ -16,30 +16,30 @@ disk_weighted_io{device="sda8"} 160
 # HELP host_uptime The uptime of the operating system
 # TYPE host_uptime gauge
 host_uptime{kernel_version="4.14.127+",os_version="cos 73-11647.217.0"} 81
-# HELP problem_counter Number of times a specific type of problem have occurred.
-# TYPE problem_counter counter
-problem_counter{reason="AUFSUmountHung"} 0
-problem_counter{reason="ContainerdStart"} 1
-problem_counter{reason="CorruptDockerImage"} 0
-problem_counter{reason="CorruptDockerOverlay2"} 0
-problem_counter{reason="DockerHung"} 0
-problem_counter{reason="DockerStart"} 1
-problem_counter{reason="FilesystemIsReadOnly"} 0
-problem_counter{reason="FrequentContainerdRestart"} 0
-problem_counter{reason="FrequentDockerRestart"} 0
-problem_counter{reason="FrequentKubeletRestart"} 0
-problem_counter{reason="KernelOops"} 0
-problem_counter{reason="KubeletStart"} 0
-problem_counter{reason="OOMKilling"} 0
-problem_counter{reason="TaskHung"} 0
-problem_counter{reason="UnregisterNetDevice"} 0
-# HELP problem_gauge Whether a specific type of problem is affecting the node or not.
-# TYPE problem_gauge gauge
-problem_gauge{reason="AUFSUmountHung",type="KernelDeadlock"} 0
-problem_gauge{reason="CorruptDockerOverlay2",type="CorruptDockerOverlay2"} 0
-problem_gauge{reason="DockerHung",type="KernelDeadlock"} 0
-problem_gauge{reason="FilesystemIsReadOnly",type="ReadonlyFilesystem"} 0
-problem_gauge{reason="FrequentContainerdRestart",type="FrequentContainerdRestart"} 0
-problem_gauge{reason="FrequentDockerRestart",type="FrequentDockerRestart"} 0
-problem_gauge{reason="FrequentKubeletRestart",type="FrequentKubeletRestart"} 0
-problem_gauge{reason="UnregisterNetDevice",type="FrequentUnregisterNetDevice"} 0
+# HELP problem_count_total Number of times a specific type of problem have occurred.
+# TYPE problem_count_total counter
+problem_count_total{reason="AUFSUmountHung"} 0
+problem_count_total{reason="ContainerdStart"} 1
+problem_count_total{reason="CorruptDockerImage"} 0
+problem_count_total{reason="CorruptDockerOverlay2"} 0
+problem_count_total{reason="DockerHung"} 0
+problem_count_total{reason="DockerStart"} 1
+problem_count_total{reason="FilesystemIsReadOnly"} 0
+problem_count_total{reason="FrequentContainerdRestart"} 0
+problem_count_total{reason="FrequentDockerRestart"} 0
+problem_count_total{reason="FrequentKubeletRestart"} 0
+problem_count_total{reason="KernelOops"} 0
+problem_count_total{reason="KubeletStart"} 0
+problem_count_total{reason="OOMKilling"} 0
+problem_count_total{reason="TaskHung"} 0
+problem_count_total{reason="UnregisterNetDevice"} 0
+# HELP problem_state Whether a specific type of problem is affecting the node or not.
+# TYPE problem_state gauge
+problem_state{reason="AUFSUmountHung",type="KernelDeadlock"} 0
+problem_state{reason="CorruptDockerOverlay2",type="CorruptDockerOverlay2"} 0
+problem_state{reason="DockerHung",type="KernelDeadlock"} 0
+problem_state{reason="FilesystemIsReadOnly",type="ReadonlyFilesystem"} 0
+problem_state{reason="FrequentContainerdRestart",type="FrequentContainerdRestart"} 0
+problem_state{reason="FrequentDockerRestart",type="FrequentDockerRestart"} 0
+problem_state{reason="FrequentKubeletRestart",type="FrequentKubeletRestart"} 0
+problem_state{reason="UnregisterNetDevice",type="FrequentUnregisterNetDevice"} 0

--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -93,23 +93,23 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		})
 
 		ginkgo.It("NPD should not report any problem", func() {
-			err := npd.WaitForNPD(instance, []string{"problem_gauge"}, 120)
+			err := npd.WaitForNPD(instance, []string{"problem_state"}, 120)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Expect NPD to become ready in 120s, but hit error: %v", err))
 
 			assertMetricValueInBound(instance,
-				"problem_gauge", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock"},
+				"problem_state", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock"},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "DockerHung"},
+				"problem_count_total", map[string]string{"reason": "DockerHung"},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "FilesystemIsReadOnly"},
+				"problem_count_total", map[string]string{"reason": "FilesystemIsReadOnly"},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "KernelOops"},
+				"problem_count_total", map[string]string{"reason": "KernelOops"},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "OOMKilling"},
+				"problem_count_total", map[string]string{"reason": "OOMKilling"},
 				0.0, 0.0)
 		})
 	})
@@ -117,19 +117,19 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 	ginkgo.Context("When ext4 filesystem error happens", func() {
 
 		ginkgo.BeforeEach(func() {
-			err := npd.WaitForNPD(instance, []string{"problem_gauge"}, 120)
+			err := npd.WaitForNPD(instance, []string{"problem_state"}, 120)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Expect NPD to become ready in 120s, but hit error: %v", err))
 			// This will trigger a ext4 error on the boot disk, causing the boot disk mounted as read-only and systemd-journald crashing.
 			instance.RunCommandOrFail("sudo /home/kubernetes/bin/problem-maker --problem Ext4FilesystemError")
 		})
 
-		ginkgo.It("NPD should update problem_counter{reason:Ext4Error} and problem_gauge{type:ReadonlyFilesystem}", func() {
+		ginkgo.It("NPD should update problem_count_total{reason:Ext4Error} and problem_state{type:ReadonlyFilesystem}", func() {
 			time.Sleep(5 * time.Second)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "Ext4Error"},
+				"problem_count_total", map[string]string{"reason": "Ext4Error"},
 				1.0, 2.0)
 			assertMetricValueInBound(instance,
-				"problem_gauge", map[string]string{"reason": "FilesystemIsReadOnly", "type": "ReadonlyFilesystem"},
+				"problem_state", map[string]string{"reason": "FilesystemIsReadOnly", "type": "ReadonlyFilesystem"},
 				1.0, 1.0)
 		})
 
@@ -143,25 +143,25 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 	ginkgo.Context("When OOM kills and docker hung happen", func() {
 
 		ginkgo.BeforeEach(func() {
-			err := npd.WaitForNPD(instance, []string{"problem_gauge"}, 120)
+			err := npd.WaitForNPD(instance, []string{"problem_state"}, 120)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Expect NPD to become ready in 120s, but hit error: %v", err))
 			instance.RunCommandOrFail("sudo /home/kubernetes/bin/problem-maker --problem OOMKill")
 			instance.RunCommandOrFail("sudo /home/kubernetes/bin/problem-maker --problem DockerHung")
 		})
 
-		ginkgo.It("NPD should update problem_counter and problem_gauge", func() {
+		ginkgo.It("NPD should update problem_count_total and problem_state", func() {
 			time.Sleep(5 * time.Second)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "DockerHung"},
+				"problem_count_total", map[string]string{"reason": "DockerHung"},
 				1.0, 1.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "TaskHung"},
+				"problem_count_total", map[string]string{"reason": "TaskHung"},
 				1.0, 1.0)
 			assertMetricValueInBound(instance,
-				"problem_gauge", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock"},
+				"problem_state", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock"},
 				1.0, 1.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "OOMKilling"},
+				"problem_count_total", map[string]string{"reason": "OOMKilling"},
 				1.0, 1.0)
 		})
 	})


### PR DESCRIPTION
This PR implements the proposal at #326 .
/fix #326

Renamed below two metrics:
`problem_counter` -> `problem_count_total`
`problem_gauge` -> `problem_state`

This is a user-visible breaking change due the metric renaming:
1. Anyone depending on Prometheus metrics will need to change their dashboard/alerting to the new metric name.
2. Anyone depending on the reported Kubernetes events/conditions will NOT be affected.
3. Anyone depending on the Stackdriver Monitoring metrics will NOT be affected.