### PR TITLE
Ignore first collected disk stats to prevent metric distortion

### DIFF
--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -115,15 +115,6 @@ func (dc *diskCollector) collect() {
 		dc.historyIOTime[deviceName] = ioCountersStat.IoTime
 		dc.historyWeightedIO[deviceName] = ioCountersStat.WeightedIO
 
-		if !historyExist {
-			// Ignore first collected stats.
-			return
-		}
-		avgQueueLen := float64(0.0)
-		if lastIOTime != ioCountersStat.IoTime {
-			avgQueueLen = float64(ioCountersStat.WeightedIO-lastWeightedIO) / float64(ioCountersStat.IoTime-lastIOTime)
-		}
-
 		// Attach label {"device_name": deviceName} to the metrics.
 		tags := map[string]string{deviceNameLabel: deviceName}
 		if dc.mIOTime != nil {
@@ -132,8 +123,14 @@ func (dc *diskCollector) collect() {
 		if dc.mWeightedIO != nil {
 			dc.mWeightedIO.Record(tags, int64(ioCountersStat.WeightedIO-lastWeightedIO))
 		}
-		if dc.mAvgQueueLen != nil {
-			dc.mAvgQueueLen.Record(tags, avgQueueLen)
+		if historyExist {
+			avgQueueLen := float64(0.0)
+			if lastIOTime != ioCountersStat.IoTime {
+				avgQueueLen = float64(ioCountersStat.WeightedIO-lastWeightedIO) / float64(ioCountersStat.IoTime-lastIOTime)
+			}
+			if dc.mAvgQueueLen != nil {
+				dc.mAvgQueueLen.Record(tags, avgQueueLen)
+			}
 		}
 	}
 }

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -109,12 +109,16 @@ func (dc *diskCollector) collect() {
 
 	for deviceName, ioCountersStat := range ioCountersStats {
 		// Calculate average IO queue length since last measurement.
-		lastIOTime := dc.historyIOTime[deviceName]
+		lastIOTime, historyExist := dc.historyIOTime[deviceName]
 		lastWeightedIO := dc.historyWeightedIO[deviceName]
 
 		dc.historyIOTime[deviceName] = ioCountersStat.IoTime
 		dc.historyWeightedIO[deviceName] = ioCountersStat.WeightedIO
 
+		if !historyExist {
+			// Ignore first collected stats.
+			return
+		}
 		avgQueueLen := float64(0.0)
 		if lastIOTime != ioCountersStat.IoTime {
 			avgQueueLen = float64(ioCountersStat.WeightedIO-lastWeightedIO) / float64(ioCountersStat.IoTime-lastIOTime)


### PR DESCRIPTION
Disk collector depends on the last collected metrics,  which are defaulted to zero. This can cause  distortion on first time collection.