### PR TITLE
Rent Boskos project only once per test run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ test: vet fmt
 	GO111MODULE=on go test -mod vendor -timeout=1m -v -race -short -tags "$(BUILD_TAGS)" ./...
 
 e2e-test: vet fmt build-tar
-	GO111MODULE=on ginkgo -nodes=$(PARALLEL) -mod vendor -timeout=10m -v -tags "$(BUILD_TAGS)" \
+	GO111MODULE=on ginkgo -nodes=$(PARALLEL) -mod vendor -timeout=10m -v -tags "$(BUILD_TAGS)" -stream \
 	./test/e2e/metriconly/... -- \
 	-project=$(PROJECT) -zone=$(ZONE) \
 	-image=$(VM_IMAGE) -image-family=$(IMAGE_FAMILY) -image-project=$(IMAGE_PROJECT) \

--- a/test/e2e/metriconly/e2e_npd_test.go
+++ b/test/e2e/metriconly/e2e_npd_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/node-problem-detector/pkg/util/tomb"
 	"k8s.io/node-problem-detector/test/e2e/lib/gce"
 	"k8s.io/test-infra/boskos/client"
 
@@ -54,6 +55,16 @@ var boskosWaitDuration = flag.Duration("boskos-wait-duration", 2*time.Minute,
 
 var computeService *compute.Service
 
+// boskosClient helps renting project from Boskos, and is only initialized on Ginkgo node 1.
+var boskosClient *client.Client
+
+// boskosRenewingTomb stops the goroutine keep renewing the Boskos resources.
+var boskosRenewingTomb *tomb.Tomb
+
+// SynchronizedBeforeSuite and SynchronizedAfterSuite help manages singleton resource (a Boskos project) across Ginkgo nodes.
+var _ = ginkgo.SynchronizedBeforeSuite(rentBoskosProjectIfNeededOnNode1, acceptBoskosProjectIfNeededFromNode1)
+var _ = ginkgo.SynchronizedAfterSuite(func() {}, releaseBoskosResourcesOnNode1)
+
 func TestNPD(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -63,13 +74,6 @@ func TestNPD(t *testing.T) {
 	computeService, err = gce.GetComputeClient()
 	if err != nil {
 		panic(fmt.Sprintf("Unable to create gcloud compute service using defaults. Make sure you are authenticated. %v", err))
-	}
-
-	if *project == "" {
-		boskosClient := client.NewClient(*jobName, *boskosServerURL)
-		*project = acquireProjectOrDie(boskosClient)
-
-		defer releaseProjectOrDie(boskosClient)
 	}
 
 	if *artifactsDir != "" {
@@ -84,30 +88,72 @@ func TestNPD(t *testing.T) {
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "NPD Metric-only Suite", []ginkgo.Reporter{junitReporter})
 }
 
-func acquireProjectOrDie(boskosClient *client.Client) string {
+// rentBoskosProjectIfNeededOnNode1 rents a GCP project from Boskos if no GCP project is specified.
+//
+// rentBoskosProjectIfNeededOnNode1 returns a byte slice containing the project name.
+// rentBoskosProjectIfNeededOnNode1 also initializes boskosClient if necessary.
+// When the tests run in parallel mode in Ginkgo, this rentBoskosProjectIfNeededOnNode1 runs only on
+// Ginkgo node 1. The output should be shared with all other Gingko nodes so that they all use the same
+// GCP project.
+func rentBoskosProjectIfNeededOnNode1() []byte {
+	if *project != "" {
+		return []byte{}
+	}
+
 	fmt.Printf("Renting project from Boskos\n")
+	boskosClient = client.NewClient(*jobName, *boskosServerURL)
+	boskosRenewingTomb = tomb.NewTomb()
+
 	ctx, cancel := context.WithTimeout(context.Background(), *boskosWaitDuration)
 	defer cancel()
 	p, err := boskosClient.AcquireWait(ctx, *boskosProjectType, "free", "busy")
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Unable to rent project from Boskos: %v\n", err))
+	fmt.Printf("Rented project %q from Boskos\n", p.Name)
 
-	fmt.Printf("Rented project %s from Boskos", p.Name)
+	go renewBoskosProject(boskosClient, p.Name, boskosRenewingTomb)
 
-	go func(boskosClient *client.Client, projectName string) {
-		for range time.Tick(5 * time.Minute) {
-			if err := boskosClient.UpdateOne(projectName, "busy", nil); err != nil {
-				fmt.Printf("Failed to update status for project %s with Boskos: %v\n", projectName, err)
-			}
-		}
-	}(boskosClient, p.Name)
-
-	return p.Name
+	return []byte(p.Name)
 }
 
-func releaseProjectOrDie(boskosClient *client.Client) {
+// acceptBoskosProjectIfNeededFromNode1 accepts a GCP project rented from Boskos by Ginkgo node 1.
+//
+// acceptBoskosProjectIfNeededFromNode1 takes the output of rentBoskosProjectIfNeededOnNode1.
+// When the tests run in parallel mode in Ginkgo, this function runs on all Ginkgo nodes.
+func acceptBoskosProjectIfNeededFromNode1(data []byte) {
+	if *project != "" {
+		return
+	}
+
+	boskosProject := string(data)
+	fmt.Printf("Received Boskos project %q from Ginkgo node 1.\n", boskosProject)
+	*project = boskosProject
+}
+
+func renewBoskosProject(boskosClient *client.Client, projectName string, boskosRenewingTomb *tomb.Tomb) {
+	defer boskosRenewingTomb.Done()
+	for {
+		select {
+		case <-time.Tick(5 * time.Minute):
+			fmt.Printf("Renewing boskosProject %q\n", projectName)
+			if err := boskosClient.UpdateOne(projectName, "busy", nil); err != nil {
+				fmt.Printf("Failed to update status for project %q with Boskos: %v\n", projectName, err)
+			}
+		case <-boskosRenewingTomb.Stopping():
+			return
+		}
+	}
+}
+
+// releaseBoskosResourcesOnNode1 releases all rented Boskos resources if there is any.
+func releaseBoskosResourcesOnNode1() {
+	if boskosClient == nil {
+		return
+	}
+	boskosRenewingTomb.Stop()
 	if !boskosClient.HasResource() {
 		return
 	}
+	fmt.Printf("Releasing all Boskos resources.\n")
 	err := boskosClient.ReleaseAll("dirty")
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to release project to Boskos: %v", err))
 }


### PR DESCRIPTION
The e2e tests are running in parallel in different Ginkgo nodes (i.e. separate processes).

The old implementation is renting a Boskos project on each Ginkgo node. This is actually a waste of resource, because we already have VM-level isolation between test cases, we don't need project-level isolation. That could exhaust Boskos project pool.

The new implementation uses the `SynchronizedBeforeSuite()` and `SynchronizedAfterSuite()` functions to help. See the _Managing Singleton External Processes in Parallel Test Suites_ subsection in the [Ginkgo documentation for parallel tests](https://onsi.github.io/ginkgo/#parallel-specs).

Basically `rentBoskosProjectIfNeededOnNode1()` is called only once on Ginkgo node 1. It will rent a GCP project from Boskos, then pass the project name to all Ginkgo nodes. It will also spawn a goroutine to keep renewing the rented project.
The other Gingko nodes waits for node 1 to rent the project, and will then accept the project using the `acceptBoskosProjectIfNeededFromNode1()` function.
In the end, Gingko node 1 will wait for all other nodes to finish, then call the `releaseBoskosResourcesOnNode1()` function which releases the rented project.

---

[Here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/node-problem-detector/405/ci-npd-e2e-test/1213231080996343808) is the logs from a sample run:
```
GO111MODULE=on ginkgo -nodes=3 -mod vendor -timeout=10m -v -tags " journald" -stream \
./test/e2e/metriconly/... -- \
-project= -zone=us-central1-a \
-image= -image-family=cos-73-lts -image-project=cos-cloud \
-ssh-user=prow -ssh-key=/etc/ssh-key-secret/ssh-private \
-npd-build-tar=`pwd`/node-problem-detector-v0.8.0-38-gc7efa05.tar.gz \
-boskos-project-type=gce-project -job-name=ci-npd-e2e-test \
-artifacts-dir=/logs/artifacts
...
[1] Parallel test node 1/3.
...
[1] Renting project from Boskos
...
[3] Parallel test node 3/3.
...
[2] Parallel test node 2/3.
...
[1] Rented project "k8s-boskos-gce-project-04" from Boskos
[1] Received Boskos project "k8s-boskos-gce-project-04" from Ginkgo node 1.
...
[3] Received Boskos project "k8s-boskos-gce-project-04" from Ginkgo node 1.
...
[2] Received Boskos project "k8s-boskos-gce-project-04" from Ginkgo node 1.
...
[2] PASS
...
[3] PASS
[1] Releasing all Boskos resources.
...
[1] PASS
```

Most importantly, note that only Ginkgo node 1 rented the project, and all other nodes simple accepts it from node 1. And that the resource is only released after all nodes have finished.