### PR TITLE
Allow not setting initial condition to avoid marking unhealthy nodes …

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -286,11 +286,20 @@ func toConditionStatus(s cpmtypes.Status) types.ConditionStatus {
 func (c *customPluginMonitor) initializeStatus() {
 	// Initialize the default node conditions
 	c.conditions = initialConditions(c.config.DefaultConditions)
-	glog.Infof("Initialize condition generated: %+v", c.conditions)
+
+	// Initialize all conditions to their default state
+	initializedConditions := []types.Condition{}
+	for _, cond := range c.conditions {
+		if !cond.Uninitialized {
+			initializedConditions = append(initializedConditions, cond)
+		}
+	}
+	glog.Infof("Initialize condition generated: %+v", initializedConditions)
+
 	// Update the initial status
 	c.statusChan <- &types.Status{
 		Source:     c.config.Source,
-		Conditions: c.conditions,
+		Conditions: initializedConditions,
 	}
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -65,6 +65,8 @@ type Condition struct {
 	Reason string `json:"reason"`
 	// Message is a human readable message of why node goes into this condition.
 	Message string `json:"message"`
+	// Set this to not automatically set initialStatus to False when NPD starts.
+	Uninitialized bool `json:"uninitialized"`
 }
 
 // Event is the event used internally by node problem detector.


### PR DESCRIPTION
…as healthy

Fixes https://github.com/kubernetes/node-problem-detector/issues/304 and https://github.com/kubernetes/node-problem-detector/issues/428

Previously, when a node boots up. NPD sets all the custom plugin conditions to false. This would lead to marking the node as healthy when it is not known yet, because the custom checks have not ran yet. Even worse, when a node is unhealthy and NPD restarts, the node is marked as healthy.

Adding a flag option to not set initial conditions to avoid that behavior.

If this turns out fine, I would also suggest making this the new default in the next major version.

@wangzhen127 @andyxning 