### PR TITLE
avoid npd pod schedule on windows node

### DIFF
--- a/deployment/node-problem-detector.yaml
+++ b/deployment/node-problem-detector.yaml
@@ -14,6 +14,15 @@ spec:
       labels:
         app: node-problem-detector
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       containers:
       - name: node-problem-detector
         command:


### PR DESCRIPTION
Currently this daemonset cannot be run on windows nodes, so avoid scheduling on windows nodes



/assign @wangzhen127