### PR TITLE
docker image: add health-checker binary

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -21,6 +21,7 @@ RUN clean-install util-linux libsystemd0 bash
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true
 
 ADD ./bin/node-problem-detector /node-problem-detector
+ADD ./bin/health-checker /home/kubernetes/bin/health-checker
 
 # Below command depends on ENABLE_JOURNAL=1.
 ADD ./bin/log-counter /home/kubernetes/bin/log-counter


### PR DESCRIPTION
The health-checker binary added in v0.8.2 is not present in `k8s.gcr.io/node-problem-detector:v0.8.2`. The example at https://github.com/kubernetes/node-problem-detector/blob/master/config/health-checker-kubelet.json#L23 suggests is should be available, so this adds it at that path within the image.