### PR TITLE
Add healthchecker flag for kubelet healthz path

### DIFF
--- a/cmd/healthchecker/options/options.go
+++ b/cmd/healthchecker/options/options.go
@@ -38,6 +38,7 @@ type HealthCheckerOptions struct {
 	EnableRepair       bool
 	CriCtlPath         string
 	CriSocketPath      string
+	KubeletHealthzPath string
 	CoolDownTime       time.Duration
 	HealthCheckTimeout time.Duration
 }
@@ -53,6 +54,8 @@ func (hco *HealthCheckerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The path to the crictl binary. This is used to check health of cri component.")
 	fs.StringVar(&hco.CriSocketPath, "cri-socket-path", types.DefaultCriSocketPath,
 		"The path to the cri socket. Used with crictl to specify the socket path.")
+	fs.StringVar(&hco.KubeletHealthzPath, "kubelet-healthz-path", types.DefaultKubeletHealthCheckEndpoint,
+		"The path to the kubelet healthz endpoint. Used with kubelet health check.")
 	fs.DurationVar(&hco.CoolDownTime, "cooldown-time", types.DefaultCoolDownTime,
 		"The duration to wait for the service to be up before attempting repair.")
 	fs.DurationVar(&hco.HealthCheckTimeout, "health-check-timeout", types.DefaultHealthCheckTimeout,
@@ -69,6 +72,10 @@ func (hco *HealthCheckerOptions) IsValid() error {
 	// Make sure the systemd service is specified if repair is enabled.
 	if hco.EnableRepair && hco.SystemdService == "" {
 		return fmt.Errorf("systemd-service cannot be empty when repair is enabled")
+	}
+	// Make sure the kubelet healthz path is not empty for kubelet component.
+	if hco.Component == types.KubeletComponent && hco.KubeletHealthzPath == "" {
+		return fmt.Errorf("the kubelet-healthz-path cannot be empty for kubelet component")
 	}
 	// Skip checking further if the component is not cri.
 	if hco.Component != types.CRIComponent {

--- a/cmd/healthchecker/options/options_test.go
+++ b/cmd/healthchecker/options/options_test.go
@@ -34,6 +34,7 @@ func TestIsValid(t *testing.T) {
 			name: "valid component",
 			hco: HealthCheckerOptions{
 				Component: types.KubeletComponent,
+				KubeletHealthzPath: types.DefaultKubeletHealthCheckEndpoint,
 			},
 			expectError: false,
 		},
@@ -41,6 +42,14 @@ func TestIsValid(t *testing.T) {
 			name: "invalid component",
 			hco: HealthCheckerOptions{
 				Component: "wrongComponent",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty kubelet-healthz-path with kubelet",
+			hco: HealthCheckerOptions{
+				Component:          types.KubeletComponent,
+				KubeletHealthzPath: "",
 			},
 			expectError: true,
 		},

--- a/pkg/healthchecker/health_checker.go
+++ b/pkg/healthchecker/health_checker.go
@@ -99,7 +99,7 @@ func getHealthCheckFunc(hco *options.HealthCheckerOptions) func() bool {
 	case types.KubeletComponent:
 		return func() bool {
 			httpClient := http.Client{Timeout: hco.HealthCheckTimeout}
-			response, err := httpClient.Get(types.KubeletHealthCheckEndpoint)
+			response, err := httpClient.Get(hco.KubeletHealthzPath)
 			if err != nil || response.StatusCode != http.StatusOK {
 				return false
 			}

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -19,17 +19,17 @@ package types
 import "time"
 
 const (
-	DefaultCoolDownTime        = 2 * time.Minute
-	DefaultHealthCheckTimeout  = 10 * time.Second
-	CmdTimeout                 = 10 * time.Second
-	DefaultCriCtl              = "/usr/bin/crictl"
-	DefaultCriSocketPath       = "unix:///var/run/containerd/containerd.sock"
-	KubeletComponent           = "kubelet"
-	CRIComponent               = "cri"
-	DockerComponent            = "docker"
-	ContainerdService          = "containerd"
-	KubeletHealthCheckEndpoint = "http://127.0.0.1:10248/healthz"
-	UptimeTimeLayout           = "Mon 2006-01-02 15:04:05 UTC"
+	DefaultCoolDownTime               = 2 * time.Minute
+	DefaultHealthCheckTimeout         = 10 * time.Second
+	CmdTimeout                        = 10 * time.Second
+	DefaultCriCtl                     = "/usr/bin/crictl"
+	DefaultCriSocketPath              = "unix:///var/run/containerd/containerd.sock"
+	KubeletComponent                  = "kubelet"
+	CRIComponent                      = "cri"
+	DockerComponent                   = "docker"
+	ContainerdService                 = "containerd"
+	DefaultKubeletHealthCheckEndpoint = "http://127.0.0.1:10248/healthz"
+	UptimeTimeLayout                  = "Mon 2006-01-02 15:04:05 UTC"
 )
 
 type HealthChecker interface {


### PR DESCRIPTION
Add flag to health-check cmd to allow customization of the endpoint used for kubelet health checks.