### PR TITLE
Generate new status log only on condition change

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -135,7 +135,7 @@ func (c *customPluginMonitor) monitorLoop() {
 			}
 			glog.V(3).Infof("Receive new plugin result for %s: %+v", c.configPath, result)
 			status := c.generateStatus(result)
-			glog.Infof("New status generated: %+v", status)
+			glog.V(3).Infof("New status generated: %+v", status)
 			c.statusChan <- status
 		case <-c.tomb.Stopping():
 			c.plugin.Stop()
@@ -263,12 +263,17 @@ func (c *customPluginMonitor) generateStatus(result cpmtypes.Result) *types.Stat
 			}
 		}
 	}
-	return &types.Status{
+	status := &types.Status{
 		Source: c.config.Source,
 		// TODO(random-liu): Aggregate events and conditions and then do periodically report.
 		Events:     append(activeProblemEvents, inactiveProblemEvents...),
 		Conditions: c.conditions,
 	}
+	// Log only if condition has changed
+	if len(activeProblemEvents) != 0 || len(inactiveProblemEvents) != 0 {
+		glog.Infof("New status generated: %+v", status)
+	}
+	return status
 }
 
 func toConditionStatus(s cpmtypes.Status) types.ConditionStatus {

--- a/pkg/custompluginmonitor/plugin/plugin.go
+++ b/pkg/custompluginmonitor/plugin/plugin.go
@@ -107,7 +107,9 @@ func (p *Plugin) runRules() {
 
 			p.resultChan <- result
 
-			glog.Infof("Add check result %+v for rule %+v", result, rule)
+			// Let the result be logged at a higher verbosity level. If there is a change in status it is logged later.
+			glog.V(3).Infof("Add check result %+v for rule %+v", result, rule)
+			glog.Infof("Ran rule %+v", rule)
 		}(rule)
 	}
 


### PR DESCRIPTION
This is to limit the logging from custom plugin runs. Today every run is logged with the status, we can instead log the status only when there is a change in conditions.