### PR TITLE
Adding fstype and mountpoint to the disk_bytes_used metric

### DIFF
--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -39,7 +39,7 @@ Below metrics are collected from `disk` component:
 * `disk_merged_operation_count`: [# of reads/writes merged][iostat doc]
 * `disk_operation_bytes_count`: # of Bytes used for reads/writes on this device
 * `disk_operation_time`: [# of milliseconds spent reading/writing][iostat doc]
-* `disk_bytes_used`: Disk usage in Bytes. The usage state is reported under the `state` metric label (e.g. `used`, `free`). Summing values of all states yields the disk size.
+* `disk_bytes_used`: Disk usage in Bytes. The usage state is reported under the `state` metric label (e.g. `used`, `free`). Summing values of all states yields the disk size. FSType and MountPoint are also reported as additional information.
 
 The name of the disk block device is reported in the `device_name` metric label (e.g. `sda`).
 

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -145,7 +145,7 @@ func NewDiskCollectorOrDie(diskConfig *ssmtypes.DiskStatsConfig) *diskCollector 
 		"Disk bytes used, in Bytes",
 		"Byte",
 		metrics.LastValue,
-		[]string{deviceNameLabel, stateLabel})
+		[]string{deviceNameLabel, fsttypeLabel, mountPointLabel, stateLabel})
 	if err != nil {
 		glog.Fatalf("Error initializing metric for %q: %v", metrics.DiskBytesUsedID, err)
 	}
@@ -270,14 +270,16 @@ func (dc *diskCollector) collect() {
 		return
 	}
 	for _, partition := range partitions {
-		usageStat, err := disk.Usage(partition.Mountpoint)
+		mountpoint := partition.Mountpoint
+		usageStat, err := disk.Usage(mountpoint)
 		if err != nil {
 			glog.Errorf("Failed to retrieve disk usage for %q: %v", partition.Mountpoint, err)
 			continue
 		}
 		deviceName := strings.TrimPrefix(partition.Device, "/dev/")
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "free"}, int64(usageStat.Free))
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "used"}, int64(usageStat.Used))
+		fstype := partition.Fstype
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fsttypeLabel:fstype, mountPointLabel:mountpoint, stateLabel: "free"}, int64(usageStat.Free))
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fsttypeLabel:fstype, mountPointLabel:mountpoint, stateLabel: "used"}, int64(usageStat.Used))
 	}
 
 }

--- a/pkg/systemstatsmonitor/labels.go
+++ b/pkg/systemstatsmonitor/labels.go
@@ -24,3 +24,9 @@ const directionLabel = "direction"
 
 // stateLabel labels the state of disk/memory/cpu usage, e.g.: "free", "used".
 const stateLabel = "state"
+
+// fsttypeLabel labels the fst type of the disk, e.g.: "ext4", "ext2", "vfat"
+const fsttypeLabel  = "fsttype"
+
+// mountPointLabel labels the mountpoint of the monitored disk device
+const mountPointLabel	= "mountpoint"


### PR DESCRIPTION
This PR adds labels fstype and mountpoint to the disk_bytes_used metric