### PR TITLE
Fix typo in custom-plugin-monitor

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -120,7 +120,7 @@ func (c *customPluginMonitor) Stop() {
 	c.tomb.Stop()
 }
 
-// monitorLoop is the main loop of log monitor.
+// monitorLoop is the main loop of customPluginMonitor.
 func (c *customPluginMonitor) monitorLoop() {
 	c.initializeStatus()
 


### PR DESCRIPTION
It seems the system-log-monitor's code was reused in custom-plugin-monitor, but the comment is missing to change.