### PR TITLE
Add more info to disk metrics & detect docker startup failures

### DIFF
--- a/config/disk-problem-monitor.json
+++ b/config/disk-problem-monitor.json
@@ -1,0 +1,34 @@
+{
+  "plugin": "custom",
+  "pluginConfig": {
+    "invoke_interval": "30m",
+    "timeout": "5s",
+    "max_output_length": 80,
+    "concurrency": 3,
+    "enable_message_change_based_condition_update": false
+  },
+  "source": "disk-problem-monitor",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "DiskSizeCheckFailure",
+      "reason": "DiskSizeCheckSucess",
+      "message": "disk size check is successful"
+    }
+  ],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "DiskSizeCheckFailure",
+      "path": "./config/plugin/check_boot_size_failure.sh",
+      "timeout": "3s"
+    },
+    {
+      "type": "permanent",
+      "condition": "DiskSizeCheckFailure",
+      "reason": "DiskSizeCheckFailure",
+      "path": "./config/plugin/check_boot_size_failure.sh",
+      "timeout": "3s"
+    }
+  ]
+}

--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -26,6 +26,11 @@
 			"condition": "CorruptDockerOverlay2",
 			"reason": "CorruptDockerOverlay2",
 			"pattern": "returned error: readlink /var/lib/docker/overlay2.*: invalid argument.*"
+		},
+		{
+			"type": "temporary",
+			"reason": "DockerStartFailure",
+			"pattern": "OCI runtime start failed: container process is already dead: unknown$"
 		}
 	]
 }

--- a/config/plugin/check_boot_disk_resize_failure.sh
+++ b/config/plugin/check_boot_disk_resize_failure.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This plugin checks if the resize2f partition failed during the boot process.
+
+readonly OK=0
+readonly NONOK=1
+readonly UNKNOWN=2
+readonly DISKFRACTIONMINIMUM=0.9
+readonly ROOTDEVICE="sda1"
+
+if ! grep $ROOTDEVICE /proc/partitions > /dev/null; then
+  echo "Error retrieving requested disk size"
+fi
+
+readonly requestedDiskSize="$(grep $ROOTDEVICE /proc/partitions | awk 'NR == 1 {printf $3}')"
+
+if ! df -P "/dev/$ROOTDEVICE"  > /dev/null; then
+  echo "Error retrieving actual disk size"
+fi
+
+readonly actualDiskSize="$(df -P "/dev/$ROOTDEVICE" | awk 'NR == 2 {printf $2}')"
+
+readonly ratio=$(echo "$actualDiskSize/$requestedDiskSize" | bc -l)
+
+# if the ratio of actualdiskSize to requestedDiskSize is less than 0.9, then it
+# implies there is a problem occuring during the resize2f partition.
+if (( $(echo "$ratio < $DISKFRACTIONMINIMUM" | bc -l) )); then
+    echo "DiskSizeCheck failure occured"
+    exit $NONOK
+else
+    echo "DiskSizeCheck is successful"
+    exit $OK
+fi

--- a/config/systemd-monitor.json
+++ b/config/systemd-monitor.json
@@ -24,6 +24,11 @@
 			"type": "temporary",
 			"reason": "ContainerdStart",
 			"pattern": "Starting containerd container runtime..."
+		},
+		{
+			"type": "temporary",
+			"reason": "ResizeStatefulPartitionStartFailure",
+			"pattern": "Failed to start Resize stateful partition."
 		}
 	]
 }

--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -40,6 +40,7 @@ Below metrics are collected from `disk` component:
 * `disk_operation_bytes_count`: # of Bytes used for reads/writes on this device
 * `disk_operation_time`: [# of milliseconds spent reading/writing][iostat doc]
 * `disk_bytes_used`: Disk usage in Bytes. The usage state is reported under the `state` metric label (e.g. `used`, `free`). Summing values of all states yields the disk size.
+FSType and MountOptions are also reported as additional information.
 
 The name of the disk block device is reported in the `device_name` metric label (e.g. `sda`).
 

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -145,7 +145,7 @@ func NewDiskCollectorOrDie(diskConfig *ssmtypes.DiskStatsConfig) *diskCollector 
 		"Disk bytes used, in Bytes",
 		"Byte",
 		metrics.LastValue,
-		[]string{deviceNameLabel, stateLabel})
+		[]string{deviceNameLabel, fstypeLabel, mountOptionLabel, stateLabel})
 	if err != nil {
 		glog.Fatalf("Error initializing metric for %q: %v", metrics.DiskBytesUsedID, err)
 	}
@@ -276,8 +276,10 @@ func (dc *diskCollector) collect() {
 			continue
 		}
 		deviceName := strings.TrimPrefix(partition.Device, "/dev/")
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "free"}, int64(usageStat.Free))
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "used"}, int64(usageStat.Used))
+		fstype := partition.Fstype
+		opttypes := partition.Opts
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fstypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "free"}, int64(usageStat.Free))
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fstypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "used"}, int64(usageStat.Used))
 	}
 
 }

--- a/pkg/systemstatsmonitor/labels.go
+++ b/pkg/systemstatsmonitor/labels.go
@@ -24,3 +24,9 @@ const directionLabel = "direction"
 
 // stateLabel labels the state of disk/memory/cpu usage, e.g.: "free", "used".
 const stateLabel = "state"
+
+// fstypeLabel labels the fst type of the disk, e.g.: "ext4", "ext2", "vfat"
+const fstypeLabel = "fstype"
+
+// mountPointLabel labels the mountpoint of the monitored disk device
+const mountOptionLabel = "mountoption"


### PR DESCRIPTION
This PR,
- Adds fstypes and mount points as the additional information that would help in analyzing log info.
- Detect docker start up failures resulting from deadlock where multiple dockers are started at the same time.
- Detect Boot disk resize failures by comparing the reducedsize versus the actual size after resize during boot