### PR TITLE
Add more info to disk metrics

### DIFF
--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -40,6 +40,7 @@ Below metrics are collected from `disk` component:
 * `disk_operation_bytes_count`: # of Bytes used for reads/writes on this device
 * `disk_operation_time`: [# of milliseconds spent reading/writing][iostat doc]
 * `disk_bytes_used`: Disk usage in Bytes. The usage state is reported under the `state` metric label (e.g. `used`, `free`). Summing values of all states yields the disk size.
+FSType and MountOptions are also reported as additional information.
 
 The name of the disk block device is reported in the `device_name` metric label (e.g. `sda`).
 

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -145,7 +145,7 @@ func NewDiskCollectorOrDie(diskConfig *ssmtypes.DiskStatsConfig) *diskCollector 
 		"Disk bytes used, in Bytes",
 		"Byte",
 		metrics.LastValue,
-		[]string{deviceNameLabel, fstypeLabel, mountOptionLabel, stateLabel})
+		[]string{deviceNameLabel, fsTypeLabel, mountOptionLabel, stateLabel})
 	if err != nil {
 		glog.Fatalf("Error initializing metric for %q: %v", metrics.DiskBytesUsedID, err)
 	}
@@ -278,8 +278,8 @@ func (dc *diskCollector) collect() {
 		deviceName := strings.TrimPrefix(partition.Device, "/dev/")
 		fstype := partition.Fstype
 		opttypes := partition.Opts
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fstypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "free"}, int64(usageStat.Free))
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fstypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "used"}, int64(usageStat.Used))
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fsTypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "free"}, int64(usageStat.Free))
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fsTypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "used"}, int64(usageStat.Used))
 	}
 
 }

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -145,7 +145,7 @@ func NewDiskCollectorOrDie(diskConfig *ssmtypes.DiskStatsConfig) *diskCollector 
 		"Disk bytes used, in Bytes",
 		"Byte",
 		metrics.LastValue,
-		[]string{deviceNameLabel, stateLabel})
+		[]string{deviceNameLabel, fstypeLabel, mountOptionLabel, stateLabel})
 	if err != nil {
 		glog.Fatalf("Error initializing metric for %q: %v", metrics.DiskBytesUsedID, err)
 	}
@@ -276,8 +276,10 @@ func (dc *diskCollector) collect() {
 			continue
 		}
 		deviceName := strings.TrimPrefix(partition.Device, "/dev/")
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "free"}, int64(usageStat.Free))
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "used"}, int64(usageStat.Used))
+		fstype := partition.Fstype
+		opttypes := partition.Opts
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fstypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "free"}, int64(usageStat.Free))
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fstypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "used"}, int64(usageStat.Used))
 	}
 
 }

--- a/pkg/systemstatsmonitor/labels.go
+++ b/pkg/systemstatsmonitor/labels.go
@@ -24,3 +24,9 @@ const directionLabel = "direction"
 
 // stateLabel labels the state of disk/memory/cpu usage, e.g.: "free", "used".
 const stateLabel = "state"
+
+// fstypeLabel labels the fst type of the disk, e.g.: "ext4", "ext2", "vfat"
+const fstypeLabel = "fstype"
+
+// mountPointLabel labels the mountpoint of the monitored disk device
+const mountOptionLabel = "mountoption"

--- a/pkg/systemstatsmonitor/labels.go
+++ b/pkg/systemstatsmonitor/labels.go
@@ -25,8 +25,8 @@ const directionLabel = "direction"
 // stateLabel labels the state of disk/memory/cpu usage, e.g.: "free", "used".
 const stateLabel = "state"
 
-// fstypeLabel labels the fst type of the disk, e.g.: "ext4", "ext2", "vfat"
-const fstypeLabel = "fstype"
+// fsTypeLabel labels the fst type of the disk, e.g.: "ext4", "ext2", "vfat"
+const fsTypeLabel = "fstype"
 
 // mountPointLabel labels the mountpoint of the monitored disk device
 const mountOptionLabel = "mountoption"


### PR DESCRIPTION
Adds labels to the metric disk_usage_bytes fstypes and mount points as the additional information that would help in analyzing and monitor the use of the file systems
