### PR TITLE
Detect docker startup failures

### DIFF
--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -15,8 +15,8 @@
 			"message": "docker overlay2 is functioning properly"
 		},
 		{
-			"type": "DockerStartupFailure",
-			"reason": "DockerStartUpSucess",
+			"type": "DockerContainerStartupFailure",
+			"reason": "NoDockerContainerStartupFailure",
 			"message": "Successfully started docker container"
 		}
 	],
@@ -34,9 +34,9 @@
 		},
 		{
 			"type": "permanent",
-			"condition": "DockerStartupFailure",
-			"reason": "DockerStartupFailure",
-			"pattern": "OCI runtime start failed: container process is already dead: unknown$"
+			"condition": "DockerContainerStartupFailure",
+			"reason": "DockerContainerStartupFailure",
+			"pattern": "OCI runtime start failed: container process is already dead: unknown"
 		}
 	]
 }

--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -13,6 +13,11 @@
 			"type": "CorruptDockerOverlay2",
 			"reason": "NoCorruptDockerOverlay2",
 			"message": "docker overlay2 is functioning properly"
+		},
+		{
+			"type": "DockerStartupFailure",
+			"reason": "DockerStartUpSucess",
+			"message": "Successfully started docker container"
 		}
 	],
 	"rules": [
@@ -26,6 +31,12 @@
 			"condition": "CorruptDockerOverlay2",
 			"reason": "CorruptDockerOverlay2",
 			"pattern": "returned error: readlink /var/lib/docker/overlay2.*: invalid argument.*"
+		},
+		{
+			"type": "permanent",
+			"condition": "DockerStartupFailure",
+			"reason": "DockerStartupFailure",
+			"pattern": "OCI runtime start failed: container process is already dead: unknown$"
 		}
 	]
 }

--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -13,7 +13,7 @@
 			"type": "CorruptDockerOverlay2",
 			"reason": "NoCorruptDockerOverlay2",
 			"message": "docker overlay2 is functioning properly"
-		},
+		}
 	],
 	"rules": [
 		{

--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -14,11 +14,6 @@
 			"reason": "NoCorruptDockerOverlay2",
 			"message": "docker overlay2 is functioning properly"
 		},
-		{
-			"type": "DockerContainerStartupFailure",
-			"reason": "NoDockerContainerStartupFailure",
-			"message": "Successfully started docker container"
-		}
 	],
 	"rules": [
 		{
@@ -33,8 +28,7 @@
 			"pattern": "returned error: readlink /var/lib/docker/overlay2.*: invalid argument.*"
 		},
 		{
-			"type": "permanent",
-			"condition": "DockerContainerStartupFailure",
+			"type": "temporary",
 			"reason": "DockerContainerStartupFailure",
 			"pattern": "OCI runtime start failed: container process is already dead: unknown"
 		}


### PR DESCRIPTION
This PR pushes the change related to 

Detect docker start up failures resulting from deadlock where multiple dockers are started at the same time.
https://github.com/docker/for-linux/issues/647
