### PR TITLE
Adding disk_quota metric to get the disk size

### DIFF
--- a/config/system-stats-monitor.json
+++ b/config/system-stats-monitor.json
@@ -34,6 +34,9 @@
 			},
 			"disk/bytes_used": {
 				"displayName": "disk/bytes_used"
+			},
+			"disk/bytes_total": {
+				"displayName": "disk/bytes_total"
 			}
 		},
 		"includeRootBlk": true,

--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -40,7 +40,7 @@ Below metrics are collected from `disk` component:
 * `disk_operation_bytes_count`: # of Bytes used for reads/writes on this device
 * `disk_operation_time`: [# of milliseconds spent reading/writing][iostat doc]
 * `disk_bytes_used`: Disk usage in Bytes. The usage state is reported under the `state` metric label (e.g. `used`, `free`). Summing values of all states yields the disk size.
-FSType and MountOptions are also reported as additional information.
+* `disk_bytes_total`: Total disk space in Bytes. Additional information such as fstypes and mountoptions is also reported
 
 The name of the disk block device is reported in the `device_name` metric label (e.g. `sda`).
 

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -154,7 +154,7 @@ func NewDiskCollectorOrDie(diskConfig *ssmtypes.DiskStatsConfig) *diskCollector 
 	dc.mBytesTotal, err = metrics.NewInt64Metric(
 		metrics.DiskBytesTotalID,
 		diskConfig.MetricsConfigs[string(metrics.DiskBytesTotalID)].DisplayName,
-		"Disk bytes used, in Bytes",
+		"Total disk size, in Bytes",
 		"Byte",
 		metrics.LastValue,
 		[]string{deviceNameLabel, fsTypeLabel, mountOptionLabel})

--- a/pkg/util/metrics/metric.go
+++ b/pkg/util/metrics/metric.go
@@ -32,7 +32,7 @@ const (
 	DiskOpsBytesID          MetricID = "disk/operation_bytes_count"
 	DiskOpsTimeID           MetricID = "disk/operation_time"
 	DiskBytesUsedID         MetricID = "disk/bytes_used"
-	DiskBytesTotalID		    MetricID = "disk/bytes_total"
+	DiskBytesTotalID        MetricID = "disk/bytes_total"
 	HostUptimeID            MetricID = "host/uptime"
 	MemoryBytesUsedID       MetricID = "memory/bytes_used"
 	MemoryAnonymousUsedID   MetricID = "memory/anonymous_used"

--- a/pkg/util/metrics/metric.go
+++ b/pkg/util/metrics/metric.go
@@ -32,6 +32,7 @@ const (
 	DiskOpsBytesID          MetricID = "disk/operation_bytes_count"
 	DiskOpsTimeID           MetricID = "disk/operation_time"
 	DiskBytesUsedID         MetricID = "disk/bytes_used"
+	DiskBytesTotalID		    MetricID = "disk/bytes_total"
 	HostUptimeID            MetricID = "host/uptime"
 	MemoryBytesUsedID       MetricID = "memory/bytes_used"
 	MemoryAnonymousUsedID   MetricID = "memory/anonymous_used"

--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -82,6 +82,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 			assertMetricExist(gotMetrics, "disk_operation_bytes_count", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "disk_operation_time", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "disk_bytes_used", map[string]string{}, false)
+			assertMetricExist(gotMetrics, "disk_bytes_total", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "disk_io_time", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "disk_weighted_io", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "memory_bytes_used", map[string]string{}, false)


### PR DESCRIPTION
Collecting FSType and Mountoptions would be helpful to track the use of file system types. But adding fields to the existing metric is a breaking change because the fields would be suprising to the customers using with alerts. So removed the fstypes and mountoptions on the existing metric 'disk_bytes_used'.
Collecting the size of the boot disk would help in identifying the inconsistencies of the file system with the device. Adding metric 'disk_bytes_total' to track the size of the boot disk with the fstypes and mountoptions.