### PR TITLE
Fix for issue https://github.com/kubernetes/node-problem-detector/issues/471

### DIFF
--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -40,7 +40,6 @@ Below metrics are collected from `disk` component:
 * `disk_operation_bytes_count`: # of Bytes used for reads/writes on this device
 * `disk_operation_time`: [# of milliseconds spent reading/writing][iostat doc]
 * `disk_bytes_used`: Disk usage in Bytes. The usage state is reported under the `state` metric label (e.g. `used`, `free`). Summing values of all states yields the disk size.
-FSType and MountOptions are also reported as additional information.
 
 The name of the disk block device is reported in the `device_name` metric label (e.g. `sda`).
 

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -145,7 +145,7 @@ func NewDiskCollectorOrDie(diskConfig *ssmtypes.DiskStatsConfig) *diskCollector 
 		"Disk bytes used, in Bytes",
 		"Byte",
 		metrics.LastValue,
-		[]string{deviceNameLabel, fsTypeLabel, mountOptionLabel, stateLabel})
+		[]string{deviceNameLabel, stateLabel})
 	if err != nil {
 		glog.Fatalf("Error initializing metric for %q: %v", metrics.DiskBytesUsedID, err)
 	}
@@ -276,10 +276,8 @@ func (dc *diskCollector) collect() {
 			continue
 		}
 		deviceName := strings.TrimPrefix(partition.Device, "/dev/")
-		fstype := partition.Fstype
-		opttypes := partition.Opts
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fsTypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "free"}, int64(usageStat.Free))
-		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, fsTypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "used"}, int64(usageStat.Used))
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "free"}, int64(usageStat.Free))
+		dc.mBytesUsed.Record(map[string]string{deviceNameLabel: deviceName, stateLabel: "used"}, int64(usageStat.Used))
 	}
 
 }


### PR DESCRIPTION
 Removing the labels fstype and options as the disk_bytes_used metric should report only size