### PR TITLE
catching hung task with pattern like "tasks airflow scheduler: *"

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -26,7 +26,7 @@
 		{
 			"type": "temporary",
 			"reason": "TaskHung",
-			"pattern": "task [\\S\\s]+:\\w+ blocked for more than \\w+ seconds\\."
+			"pattern": "task [\\S ]+:\\w+ blocked for more than \\w+ seconds\\."
 		},
 		{
 			"type": "temporary",

--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -26,7 +26,7 @@
 		{
 			"type": "temporary",
 			"reason": "TaskHung",
-			"pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
+			"pattern": "task [\\S\\s]+:\\w+ blocked for more than \\w+ seconds\\."
 		},
 		{
 			"type": "temporary",


### PR DESCRIPTION
some of the events of the pattern "task airflow scheduler: *" is not been identified. changing the pattern to catch this type events