### PR TITLE
fix: node memory metrics are off by 1024

### DIFF
--- a/pkg/systemstatsmonitor/memory_collector.go
+++ b/pkg/systemstatsmonitor/memory_collector.go
@@ -115,29 +115,29 @@ func (mc *memoryCollector) collect() {
 
 	if mc.mBytesUsed != nil {
 		memUsed := meminfo.MemTotal - meminfo.MemFree - meminfo.Buffers - meminfo.Cached - meminfo.Slab
-		mc.mBytesUsed.Record(map[string]string{stateLabel: "free"}, int64(meminfo.MemFree))
-		mc.mBytesUsed.Record(map[string]string{stateLabel: "used"}, int64(memUsed))
-		mc.mBytesUsed.Record(map[string]string{stateLabel: "buffered"}, int64(meminfo.Buffers))
-		mc.mBytesUsed.Record(map[string]string{stateLabel: "cached"}, int64(meminfo.Cached))
-		mc.mBytesUsed.Record(map[string]string{stateLabel: "slab"}, int64(meminfo.Slab))
+		mc.mBytesUsed.Record(map[string]string{stateLabel: "free"}, int64(meminfo.MemFree)*1024)
+		mc.mBytesUsed.Record(map[string]string{stateLabel: "used"}, int64(memUsed)*1024)
+		mc.mBytesUsed.Record(map[string]string{stateLabel: "buffered"}, int64(meminfo.Buffers)*1024)
+		mc.mBytesUsed.Record(map[string]string{stateLabel: "cached"}, int64(meminfo.Cached)*1024)
+		mc.mBytesUsed.Record(map[string]string{stateLabel: "slab"}, int64(meminfo.Slab)*1024)
 	}
 
 	if mc.mDirtyUsed != nil {
-		mc.mDirtyUsed.Record(map[string]string{stateLabel: "dirty"}, int64(meminfo.Dirty))
-		mc.mDirtyUsed.Record(map[string]string{stateLabel: "writeback"}, int64(meminfo.Writeback))
+		mc.mDirtyUsed.Record(map[string]string{stateLabel: "dirty"}, int64(meminfo.Dirty)*1024)
+		mc.mDirtyUsed.Record(map[string]string{stateLabel: "writeback"}, int64(meminfo.Writeback)*1024)
 	}
 
 	if mc.mAnonymousUsed != nil {
-		mc.mAnonymousUsed.Record(map[string]string{stateLabel: "active"}, int64(meminfo.ActiveAnon))
-		mc.mAnonymousUsed.Record(map[string]string{stateLabel: "inactive"}, int64(meminfo.InactiveAnon))
+		mc.mAnonymousUsed.Record(map[string]string{stateLabel: "active"}, int64(meminfo.ActiveAnon)*1024)
+		mc.mAnonymousUsed.Record(map[string]string{stateLabel: "inactive"}, int64(meminfo.InactiveAnon)*1024)
 	}
 
 	if mc.mPageCacheUsed != nil {
-		mc.mPageCacheUsed.Record(map[string]string{stateLabel: "active"}, int64(meminfo.ActiveFile))
-		mc.mPageCacheUsed.Record(map[string]string{stateLabel: "inactive"}, int64(meminfo.InactiveFile))
+		mc.mPageCacheUsed.Record(map[string]string{stateLabel: "active"}, int64(meminfo.ActiveFile)*1024)
+		mc.mPageCacheUsed.Record(map[string]string{stateLabel: "inactive"}, int64(meminfo.InactiveFile)*1024)
 	}
 
 	if mc.mUnevictableUsed != nil {
-		mc.mUnevictableUsed.Record(map[string]string{}, int64(meminfo.Unevictable))
+		mc.mUnevictableUsed.Record(map[string]string{}, int64(meminfo.Unevictable)*1024)
 	}
 }


### PR DESCRIPTION
The memory unit in `/proc/meminfo` is kB. The unit is considered in `prometheus/procfs` when reading meminfo.

```sh
# cat /proc/meminfo
MemTotal:       264129908 kB
MemFree:        153559480 kB
...
```

- b/171164235