### PR TITLE
Adapt OOMKilling pattern to old and new Linux kernels

### DIFF
--- a/config/kernel-monitor-filelog.json
+++ b/config/kernel-monitor-filelog.json
@@ -20,7 +20,7 @@
 		{
 			"type": "temporary",
 			"reason": "OOMKilling",
-			"pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
+			"pattern": "Killed process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
 		},
 		{
 			"type": "temporary",

--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -21,7 +21,7 @@
 		{
 			"type": "temporary",
 			"reason": "OOMKilling",
-			"pattern": "Kill process \\d+ (.+) score \\d+ or sacrifice child\\nKilled process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
+			"pattern": "Killed process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
 		},
 		{
 			"type": "temporary",


### PR DESCRIPTION
Context: https://github.com/kubernetes/node-problem-detector/issues/480.

Tl;dr: kernel commit https://github.com/torvalds/linux/commit/bbbe48029720d2c6b6733f78d02571a281511adb removed logging the `Kill process %d (%s) score %u or sacrifice child\n` OOM message part we look for when tracing the kernel log in the kernel monitor. Because of that, the change removes that part from the `kernel-monitor(-filelog).json` regex pattern to handle both old and new kernel versions.

Successfully tested the change using https://github.com/kubernetes/node-problem-detector#try-it-out instruction (appropriate K8s events are emitted for both old and new OOM message formats).

Fixes https://github.com/kubernetes/node-problem-detector/issues/480.