### PR TITLE
Add Detectection logic for  I/O errors

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -54,6 +54,11 @@
 			"pattern": "EXT4-fs warning .*"
 		},
 		{
+			"type": "temporary",
+			"reason": "IOError",
+			"pattern": "Buffer I/O error .*"
+		},
+		{
 			"type": "permanent",
 			"condition": "KernelDeadlock",
 			"reason": "AUFSUmountHung",


### PR DESCRIPTION
Add logic for detecting IO errors:

error pattern: Buffer I/O error on dev sdb, logical block 1039, lost async page write