### PR TITLE
Kubelet api server connection check in health checker

### DIFF
--- a/cmd/healthchecker/health_checker.go
+++ b/cmd/healthchecker/health_checker.go
@@ -49,7 +49,12 @@ func main() {
 		fmt.Println(err)
 		os.Exit(int(types.Unknown))
 	}
-	if !hc.CheckHealth() {
+	healthy, err := hc.CheckHealth()
+	if err != nil {
+		fmt.Printf("error checking %v health: %v\n", hco.Component, err)
+		os.Exit(int(types.Unknown))
+	}
+	if !healthy {
 		fmt.Printf("%v:%v was found unhealthy; repair flag : %v\n", hco.Component, hco.SystemdService, hco.EnableRepair)
 		os.Exit(int(types.NonOK))
 	}

--- a/pkg/healthchecker/health_checker_test.go
+++ b/pkg/healthchecker/health_checker_test.go
@@ -25,7 +25,7 @@ import (
 
 var repairCalled bool
 
-func NewTestHealthChecker(repairFunc func(), healthCheckFunc func() bool, uptimeFunc func() (time.Duration, error), enableRepair bool) types.HealthChecker {
+func NewTestHealthChecker(repairFunc func(), healthCheckFunc func() (bool, error), uptimeFunc func() (time.Duration, error), enableRepair bool) types.HealthChecker {
 	repairCalled = false
 	return &healthChecker{
 		enableRepair:       enableRepair,
@@ -37,12 +37,12 @@ func NewTestHealthChecker(repairFunc func(), healthCheckFunc func() bool, uptime
 	}
 }
 
-func healthyFunc() bool {
-	return true
+func healthyFunc() (bool, error) {
+	return true, nil
 }
 
-func unhealthyFunc() bool {
-	return false
+func unhealthyFunc() (bool, error) {
+	return false, nil
 }
 
 func repairFunc() {
@@ -62,7 +62,7 @@ func TestHealthCheck(t *testing.T) {
 		description     string
 		enableRepair    bool
 		healthy         bool
-		healthCheckFunc func() bool
+		healthCheckFunc func() (bool, error)
 		uptimeFunc      func() (time.Duration, error)
 		repairFunc      func()
 		repairCalled    bool
@@ -106,7 +106,10 @@ func TestHealthCheck(t *testing.T) {
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			hc := NewTestHealthChecker(tc.repairFunc, tc.healthCheckFunc, tc.uptimeFunc, tc.enableRepair)
-			healthy := hc.CheckHealth()
+			healthy, err := hc.CheckHealth()
+			if err != nil {
+				t.Errorf("unexpected error occurred got %v; expected nil", err)
+			}
 			if healthy != tc.healthy {
 				t.Errorf("incorrect health returned got %t; expected %t", healthy, tc.healthy)
 			}

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -19,19 +19,25 @@ package types
 import "time"
 
 const (
-	DefaultCoolDownTime        = 2 * time.Minute
-	DefaultHealthCheckTimeout  = 10 * time.Second
-	CmdTimeout                 = 10 * time.Second
-	DefaultCriCtl              = "/usr/bin/crictl"
-	DefaultCriSocketPath       = "unix:///var/run/containerd/containerd.sock"
-	KubeletComponent           = "kubelet"
-	CRIComponent               = "cri"
-	DockerComponent            = "docker"
-	ContainerdService          = "containerd"
-	KubeletHealthCheckEndpoint = "http://127.0.0.1:10248/healthz"
-	UptimeTimeLayout           = "Mon 2006-01-02 15:04:05 UTC"
+	DefaultCoolDownTime       = 2 * time.Minute
+	DefaultHealthCheckTimeout = 10 * time.Second
+	CmdTimeout                = 10 * time.Second
+	UptimeTimeLayout          = "Mon 2006-01-02 15:04:05 UTC"
+	LogParsingTimeLayout      = "2006-01-02 15:04:05"
+
+	DefaultCriCtl        = "/usr/bin/crictl"
+	DefaultCriSocketPath = "unix:///var/run/containerd/containerd.sock"
+
+	KubeletComponent  = "kubelet"
+	CRIComponent      = "cri"
+	DockerComponent   = "docker"
+	ContainerdService = "containerd"
+
+	KubeletHealthCheckEndpoint                      = "http://127.0.0.1:10248/healthz"
+	KubeletClosedConnectionLogPattern               = "use of closed network connection"
+	KubeletClosedConnectionLogPatternThresholdCount = 10
 )
 
 type HealthChecker interface {
-	CheckHealth() bool
+	CheckHealth() (bool, error)
 }


### PR DESCRIPTION
This CL adds a check for kubelet-apiserver connection lost issue([#87615](https://github.com/kubernetes/kubernetes/issues/87615)) in kubelet health checker. If found unhealthy, the health checker will restart kubelet to restore the connection.

Detection of the lost connection is repeated occurrence of "use of closed network connection" in kubelet logs.

The kubelet health check is currently extended by adding code for the specific case but in the long run it makes sense to make it more generic/extensible by allowing to add more to health checks through a well defined interface. That can be improved when we have more use cases for such extensions.