### PR TITLE
add code to retrieve kernel modules in a linux system from /proc/modules.

### DIFF
--- a/config/system-stats-monitor.json
+++ b/config/system-stats-monitor.json
@@ -6,6 +6,15 @@
 			},
 			"cpu/usage_time": {
 				"displayName": "cpu/usage_time"
+      },
+      "cpu/load_1m": {
+				"displayName": "cpu/load_1m"
+      },
+      "cpu/load_5m": {
+				"displayName": "cpu/load_5m"
+      },
+      "cpu/load_15m": {
+				"displayName": "cpu/load_15m"
 			}
 		}
 	},

--- a/pkg/exporters/stackdriver/stackdriver_exporter.go
+++ b/pkg/exporters/stackdriver/stackdriver_exporter.go
@@ -49,6 +49,9 @@ const exporterName = "stackdriver"
 var NPDMetricToSDMetric = map[metrics.MetricID]string{
 	metrics.CPURunnableTaskCountID:  "compute.googleapis.com/guest/cpu/runnable_task_count",
 	metrics.CPUUsageTimeID:          "compute.googleapis.com/guest/cpu/usage_time",
+	metrics.CPULoad1m:               "compute.googleapis.com/guest/cpu/load_1m",
+	metrics.CPULoad5m:               "compute.googleapis.com/guest/cpu/load_5m",
+	metrics.CPULoad15m:              "compute.googleapis.com/guest/cpu/load_15m",
 	metrics.DiskAvgQueueLenID:       "compute.googleapis.com/guest/disk/queue_length",
 	metrics.DiskBytesUsedID:         "compute.googleapis.com/guest/disk/bytes_used",
 	metrics.DiskIOTimeID:            "compute.googleapis.com/guest/disk/io_time",

--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -25,6 +25,9 @@ Below metrics are collected from `cpu` component:
 
 * `cpu_runnable_task_count`: The average number of runnable tasks in the run-queue during the last minute. Collected from [`/proc/loadavg`][/proc doc].
 * `cpu_usage_time`: CPU usage, in seconds. The [CPU state][/proc doc] for the corresponding usage is reported under the `state` metric label (e.g. `user`, `nice`, `system`...).
+* `cpu_load_1m`: CPU load average over the last 1 minute. Collected from [`/proc/loadavg`][/proc doc].
+* `cpu_load_5m`: CPU load average over the last 5 minutes. Collected from [`/proc/loadavg`][/proc doc].
+* `cpu_load_15m`: CPU load average over the last 15 minutes. Collected from [`/proc/loadavg`][/proc doc].
 
 [/proc doc]: http://man7.org/linux/man-pages/man5/proc.5.html
 

--- a/pkg/systemstatsmonitor/cpu_collector.go
+++ b/pkg/systemstatsmonitor/cpu_collector.go
@@ -38,6 +38,9 @@ const clockTick float64 = 100.0
 type cpuCollector struct {
 	mRunnableTaskCount *metrics.Float64Metric
 	mUsageTime         *metrics.Float64Metric
+	mCpuLoad1m         *metrics.Float64Metric
+	mCpuLoad5m         *metrics.Float64Metric
+	mCpuLoad15m        *metrics.Float64Metric
 
 	config *ssmtypes.CPUStatsConfig
 
@@ -71,6 +74,39 @@ func NewCPUCollectorOrDie(cpuConfig *ssmtypes.CPUStatsConfig) *cpuCollector {
 		glog.Fatalf("Error initializing metric for %q: %v", metrics.CPUUsageTimeID, err)
 	}
 
+	cc.mCpuLoad1m, err = metrics.NewFloat64Metric(
+		metrics.CPULoad1m,
+		cpuConfig.MetricsConfigs[string(metrics.CPULoad1m)].DisplayName,
+		"CPU average load (1m)",
+		"1",
+		metrics.LastValue,
+		[]string{})
+	if err != nil {
+		glog.Fatalf("Error initializing metric for %q: %v", metrics.CPULoad1m, err)
+	}
+
+	cc.mCpuLoad5m, err = metrics.NewFloat64Metric(
+		metrics.CPULoad5m,
+		cpuConfig.MetricsConfigs[string(metrics.CPULoad5m)].DisplayName,
+		"CPU average load (5m)",
+		"1",
+		metrics.LastValue,
+		[]string{})
+	if err != nil {
+		glog.Fatalf("Error initializing metric for %q: %v", metrics.CPULoad5m, err)
+	}
+
+	cc.mCpuLoad15m, err = metrics.NewFloat64Metric(
+		metrics.CPULoad15m,
+		cpuConfig.MetricsConfigs[string(metrics.CPULoad15m)].DisplayName,
+		"CPU average load (15m)",
+		"1",
+		metrics.LastValue,
+		[]string{})
+	if err != nil {
+		glog.Fatalf("Error initializing metric for %q: %v", metrics.CPULoad15m, err)
+	}
+
 	cc.lastUsageTime = make(map[string]float64)
 
 	return &cc
@@ -88,6 +124,10 @@ func (cc *cpuCollector) recordLoad() {
 	}
 
 	cc.mRunnableTaskCount.Record(map[string]string{}, loadAvg.Load1)
+
+	cc.mCpuLoad1m.Record(map[string]string{}, loadAvg.Load1)
+	cc.mCpuLoad5m.Record(map[string]string{}, loadAvg.Load5)
+	cc.mCpuLoad15m.Record(map[string]string{}, loadAvg.Load15)
 }
 
 func (cc *cpuCollector) recordUsage() {

--- a/pkg/util/metrics/metric.go
+++ b/pkg/util/metrics/metric.go
@@ -22,6 +22,9 @@ import (
 const (
 	CPURunnableTaskCountID  MetricID = "cpu/runnable_task_count"
 	CPUUsageTimeID          MetricID = "cpu/usage_time"
+	CPULoad1m               MetricID = "cpu/load_1m"
+	CPULoad5m               MetricID = "cpu/load_5m"
+	CPULoad15m              MetricID = "cpu/load_15m"
 	ProblemCounterID        MetricID = "problem_counter"
 	ProblemGaugeID          MetricID = "problem_gauge"
 	DiskIOTimeID            MetricID = "disk/io_time"

--- a/pkg/util/metrics/system/common.go
+++ b/pkg/util/metrics/system/common.go
@@ -1,0 +1,1 @@
+package system

--- a/pkg/util/metrics/system/common.go
+++ b/pkg/util/metrics/system/common.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package system
 
 import (

--- a/pkg/util/metrics/system/common.go
+++ b/pkg/util/metrics/system/common.go
@@ -1,1 +1,25 @@
 package system
+
+import (
+	"bufio"
+	"os"
+)
+
+// ReadFile reads contents from a file and returns lines.
+func ReadFile(filename string) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var result []string
+	s := bufio.NewScanner(file)
+	for s.Scan() {
+		result = append(result, s.Text())
+	}
+	if s.Err() != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/util/metrics/system/module_stats.go
+++ b/pkg/util/metrics/system/module_stats.go
@@ -1,11 +1,10 @@
-package kernel
+package system
 
 import (
-	"bufio"
 	"os"
 	"strconv"
 	"strings"
-	)
+)
 
 type ModuleStat struct {
 	ModuleName				string  `json:"moduleName"`
@@ -51,24 +50,6 @@ func Modules() ([]ModuleStat, error) {
 			Unsigned: 		isUnsigned,
 		}
 		result = append(result, stats)
-	}
-	return result, nil
-}
-
-func ReadFile(filename string) ([]string, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var result []string
-	s := bufio.NewScanner(file)
-	for s.Scan() {
-		result = append(result, s.Text())
-	}
-	if s.Err() != nil {
-		return nil, err
 	}
 	return result, nil
 }

--- a/pkg/util/metrics/system/module_stats.go
+++ b/pkg/util/metrics/system/module_stats.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package system
 
 import (

--- a/pkg/util/metrics/system/module_stats.go
+++ b/pkg/util/metrics/system/module_stats.go
@@ -70,11 +70,11 @@ func Modules() ([]ModuleStat, error) {
 			isUnsigned = strings.Contains(fields[6], "E")
 		}
 		var stats = ModuleStat{
-			ModuleName:  moduleName,
-			Instances:   numberOfInstances,
-			Proprietary: isProprietary,
-			OutOfTree:   isOutofTree,
-			Unsigned:    isUnsigned,
+			ModuleName:		moduleName,
+			Instances: 		numberOfInstances,
+			Proprietary:  isProprietary,
+			OutOfTree:    isOutofTree,
+			Unsigned: 		isUnsigned,
 		}
 		result = append(result, stats)
 	}

--- a/pkg/util/metrics/system/module_stats.go
+++ b/pkg/util/metrics/system/module_stats.go
@@ -1,0 +1,74 @@
+package kernel
+
+import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
+	)
+
+type ModuleStat struct {
+	ModuleName				string  `json:"moduleName"`
+	Instances         uint64  `json:"instances"`
+	Proprietary       bool    `json:"proprietary"`
+	OutOfTree         bool    `json:"outOfTree"`
+	Unsigned          bool    `json:"unsigned"`
+}
+
+// Module returns all the kernel modules and their
+// usage. It is read from cat /proc/modules.
+func Modules() ([]ModuleStat, error) {
+	filename := "/proc/modules"
+	if _, err := os.Stat(filename); err != nil {
+		return nil, err
+	}
+	lines, _ := ReadFile(filename)
+	var result = make([]ModuleStat, 0, len(lines))
+
+	// a line of /proc/modules has the following structure
+	// nf_nat 61440 2 xt_MASQUERADE,iptable_nat, Live 0x0000000000000000  (O)
+	// (1)		(2)  (3)    (4)										 (5)	 	(6)								(7)
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		moduleName := fields[0]
+		numberOfInstances, err := strconv.ParseUint((fields[1]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		var isProprietary = false
+		var isOutofTree = false
+		var isUnsigned = false
+		if len(fields) > 6 {
+			isProprietary = strings.Contains(fields[6], "P")
+			isOutofTree = strings.Contains(fields[6], "O")
+			isUnsigned = strings.Contains(fields[6], "E")
+		}
+		var stats = ModuleStat{
+			ModuleName:		moduleName,
+			Instances: 		numberOfInstances,
+			Proprietary:  isProprietary,
+			OutOfTree:    isOutofTree,
+			Unsigned: 		isUnsigned,
+		}
+		result = append(result, stats)
+	}
+	return result, nil
+}
+
+func ReadFile(filename string) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var result []string
+	s := bufio.NewScanner(file)
+	for s.Scan() {
+		result = append(result, s.Text())
+	}
+	if s.Err() != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/util/metrics/system/module_stats_test.go
+++ b/pkg/util/metrics/system/module_stats_test.go
@@ -27,7 +27,7 @@ func TestModules(t *testing.T) {
 		t.Errorf("error %v", err)
 	}
 	if modules == nil {
-		t.Errorf("Could not get up time %v", v)
+		t.Error("Could not retrieve modules")
 	}
 }
 

--- a/pkg/util/metrics/system/module_stats_test.go
+++ b/pkg/util/metrics/system/module_stats_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestModules(t *testing.T) {
+	modules, err := Modules()
+	if err != nil {
+		t.Errorf("error %v", err)
+	}
+	if modules == nil {
+		t.Errorf("Could not get up time %v", v)
+	}
+}
+
+func TestModuleStat_String(t *testing.T) {
+	v := ModuleStat{
+		ModuleName: "test",
+		Instances:  2,
+		OutOfTree:  false,
+		Unsigned:   false,
+	}
+	e := `{"moduleName":"test", "instances": 2, Proprietary: false,"OutOfTree": false,"Unsigned":   false}`
+	if e != fmt.Sprintf("%v", v) {
+		t.Errorf("ModuleStat string is invalid:\ngot  %v\nexpected %v", v, e)
+	}
+}

--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -77,6 +77,9 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 
 			assertMetricExist(gotMetrics, "cpu_runnable_task_count", map[string]string{}, true)
 			assertMetricExist(gotMetrics, "cpu_usage_time", map[string]string{}, false)
+			assertMetricExist(gotMetrics, "cpu_load_1m", map[string]string{}, false)
+			assertMetricExist(gotMetrics, "cpu_load_5m", map[string]string{}, false)
+			assertMetricExist(gotMetrics, "cpu_load_15m", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "disk_operation_count", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "disk_merged_operation_count", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "disk_operation_bytes_count", map[string]string{}, false)


### PR DESCRIPTION
Added code to retrieve kernel modules as a first step to add metrics that list all the modules and the number of instances. This metric would be useful in analyzing the usage of different modules.