### PR TITLE
add new metric to identify boot disk size

### DIFF
--- a/config/system-stats-monitor.json
+++ b/config/system-stats-monitor.json
@@ -20,6 +20,9 @@
 	},
 	"disk": {
 		"metricsConfigs": {
+			"boot_disk_size": {
+				"displayName": "boot_disk_size"
+			},
 			"disk/io_time": {
 				"displayName": "disk/io_time"
 			},

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -321,11 +321,12 @@ func listRootBlockDevices(timeout time.Duration) map[string]int64 {
 	// "-d" prevents printing slave or holder devices. i.e. /dev/sda1, /dev/sda2...
 	// "-n" prevents printing the headings.
 	// "-p NAME" specifies to only print the device name.
-	cmd := exec.CommandContext(ctx, "lsblk", "-d", "-n", "-o", "NAME,SIZE")
+	cmd := exec.CommandContext(ctx, "lsblk", "-d", "-nb", "-o", "NAME,SIZE")
 	stdout, err := cmd.Output()
 	if err != nil {
 		glog.Errorf("Error calling lsblk")
 	}
+
 	lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
 	result := make(map[string]int64)
 	for _, line := range lines {

--- a/pkg/util/metrics/metric.go
+++ b/pkg/util/metrics/metric.go
@@ -20,6 +20,7 @@ import (
 )
 
 const (
+	BootDiskSizeID          MetricID = "boot_disk_size"
 	CPURunnableTaskCountID  MetricID = "cpu/runnable_task_count"
 	CPUUsageTimeID          MetricID = "cpu/usage_time"
 	CPULoad1m               MetricID = "cpu/load_1m"


### PR DESCRIPTION
added a new metric boot_disk_size in the disk collector to identify the boot disk size of all the attached boot disks.

the output of the metric would be:

boot_disk_size{device_name="loop0"} 5.36870912e+11
boot_disk_size{device_name="sda"} 2.147483648e+12
