### PR TITLE
avoid duplicating the disk bytes used metrics based on fstype and mount types

### DIFF
--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -269,7 +269,16 @@ func (dc *diskCollector) collect() {
 	if dc.mBytesUsed == nil {
 		return
 	}
+
+	// to make sure that the rows are not duplicated
+	// we display only the only one row even if there are
+	// mutiple rows for the same disk.
+	seen := make(map[string]bool)
 	for _, partition := range partitions {
+		if seen[partition.Device] {
+			continue
+		}
+		seen[partition.Device] = true
 		usageStat, err := disk.Usage(partition.Mountpoint)
 		if err != nil {
 			glog.Errorf("Failed to retrieve disk usage for %q: %v", partition.Mountpoint, err)


### PR DESCRIPTION
sometimes the disk bytes used metrics reports duplicate rows when with fstype and mount opts. Fixed the issue by making sure that the disk bytes used is reported only once per disk partition even if there are multiple rows.