### PR TITLE
Change default staging bucket.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ VERSION?=$(shell if [ -d .git ]; then echo `git describe --tags --dirty`; else e
 TAG?=$(VERSION)
 
 # REGISTRY is the container registry to push into.
-REGISTRY?=staging-k8s.gcr.io
+REGISTRY?=gcr.io/k8s-staging-npd
 
 # UPLOAD_PATH is the cloud storage path to upload release tar.
 UPLOAD_PATH?=gs://kubernetes-release


### PR DESCRIPTION
The new staging bucket for the promoter is `gcr.io/k8s-staging-npd`.