### PR TITLE
Support filelog watching in Windows.

### DIFF
--- a/config/windows-containerd-monitor-filelog.json
+++ b/config/windows-containerd-monitor-filelog.json
@@ -1,0 +1,20 @@
+{
+	"plugin": "filelog",
+	"pluginConfig": {
+		"timestamp": "^time=\"(\\S*)\"",
+		"message": "msg=\"([^\n]*)\"",
+		"timestampFormat": "2006-01-02T15:04:05.999999999-07:00"
+	},
+	"logPath": "C:\\Program Files\\containerd\\containerd.log",
+	"lookback": "5m",
+	"bufferSize": 10,
+	"source": "docker-monitor",
+	"conditions": [],
+	"rules": [
+		{
+			"type": "temporary",
+			"reason": "BadCNIConfig",
+			"pattern": "failed to reload cni configuration.*"
+		}
+	]
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/cadvisor v0.36.0
+	github.com/hpcloud/tail v1.0.0
 	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.7.1
 	github.com/pborman/uuid v1.2.0

--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_windows.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_windows.go
@@ -17,13 +17,13 @@ limitations under the License.
 package filelog
 
 import (
-	"fmt"
 	"io"
+
+	"github.com/hpcloud/tail"
 )
 
 // getLogReader returns log reader for filelog log. Note that getLogReader doesn't look back
 // to the rolled out logs.
 func getLogReader(path string) (io.ReadCloser, error) {
-	// TODO: Support this on windows.
-	return nil, fmt.Errorf("not supported on windows.")
+	return tail.OpenFile(path)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,6 +122,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v0.0.0-20171204182908-b7773ae21874
 github.com/hashicorp/go-multierror
 # github.com/hpcloud/tail v1.0.0
+## explicit
 github.com/hpcloud/tail
 github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util


### PR DESCRIPTION
Add filelog watching support for Windows NPD. This enables NPD to run with a minimal setup.

To run NPD on Windows the following commands will work.

As an example there's a basic containerd filelog config to monitor bad CNI configurations.

```powershell
make clean windows-binaries
.\bin\node-problem-detector.exe --config.system-log-monitor .\config\windows-containerd-monitor-filelog.json --enable-k8s-exporter false
```

In addition, `ENABLE_JOURNALD` make argument is scoped to Linux binaries only.

Issue: https://github.com/kubernetes/node-problem-detector/issues/461