### PR TITLE
Use Fatal instead of panic for go tests.

### DIFF
--- a/test/e2e/metriconly/e2e_npd_test.go
+++ b/test/e2e/metriconly/e2e_npd_test.go
@@ -73,7 +73,7 @@ func TestNPD(t *testing.T) {
 	var err error
 	computeService, err = gce.GetComputeClient()
 	if err != nil {
-		panic(fmt.Sprintf("Unable to create gcloud compute service using defaults. Make sure you are authenticated. %v", err))
+		t.Fatalf("Unable to create gcloud compute service using defaults. Make sure you are authenticated. %v", err)
 	}
 
 	if *artifactsDir != "" {


### PR DESCRIPTION
Using unrecovered panics in a test immediately abort the test package.
This means some tests within a package don't get to run so feedback is cut off.