### PR TITLE
add metrics for process stats

### DIFF
--- a/config/system-stats-monitor.json
+++ b/config/system-stats-monitor.json
@@ -15,7 +15,19 @@
       },
       "cpu/load_15m": {
 				"displayName": "cpu/load_15m"
-			}
+      },
+      "system/processes_total": {
+        "displayName": "system/processes_total"
+      },
+      "system/procs_running": {
+        "displayName": "system/procs_running"
+      },
+      "system/procs_blocked": {
+        "displayName": "system/procs_blocked"
+      },
+      "system/interrupts_total": {
+        "displayName": "system/interrupts_total"
+      }
 		}
 	},
 	"disk": {

--- a/pkg/exporters/stackdriver/stackdriver_exporter.go
+++ b/pkg/exporters/stackdriver/stackdriver_exporter.go
@@ -69,6 +69,10 @@ var NPDMetricToSDMetric = map[metrics.MetricID]string{
 	metrics.ProblemCounterID:        "compute.googleapis.com/guest/system/problem_count",
 	metrics.ProblemGaugeID:          "compute.googleapis.com/guest/system/problem_state",
 	metrics.OSFeatureID:             "compute.googleapis.com/guest/system/os_feature_enabled",
+	metrics.SystemProcessesTotal:    "kubernetes.io/internal/node/guest/system/processes_total",
+	metrics.SystemProcsRunning:      "kubernetes.io/internal/node/guest/system/procs_running",
+	metrics.SystemProcsBlocked:      "kubernetes.io/internal/node/guest/system/procs_blocked",
+	metrics.SystemInterruptsTotal:   "kubernetes.io/internal/node/guest/system/interrupts_total",
 }
 
 func getMetricTypeConversionFunction(customMetricPrefix string) func(*view.View) string {

--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -28,6 +28,10 @@ Below metrics are collected from `cpu` component:
 * `cpu_load_1m`: CPU load average over the last 1 minute. Collected from [`/proc/loadavg`][/proc doc].
 * `cpu_load_5m`: CPU load average over the last 5 minutes. Collected from [`/proc/loadavg`][/proc doc].
 * `cpu_load_15m`: CPU load average over the last 15 minutes. Collected from [`/proc/loadavg`][/proc doc].
+* `system/processes_total`: Number of forks since boot.
+* `system/procs_running`: Number of processes currently running.
+* `system/procs_blocked`: Number of processes currently blocked.
+* `system/interrupts_total`: Total number of interrupts serviced (cumulative).
 
 [/proc doc]: http://man7.org/linux/man-pages/man5/proc.5.html
 

--- a/pkg/systemstatsmonitor/labels.go
+++ b/pkg/systemstatsmonitor/labels.go
@@ -36,3 +36,9 @@ const featureLabel = "os_feature"
 
 // valueLabel labels the value for the features of the guest os system if required
 const valueLabel = "value"
+
+// osVersionLabel labels the OS
+const osVersionLabel = "os_version"
+
+// osVersionLabel labels the kernel version
+const kernelVersionLabel = "kernel_version"

--- a/pkg/systemstatsmonitor/osfeature_collector.go
+++ b/pkg/systemstatsmonitor/osfeature_collector.go
@@ -142,6 +142,9 @@ func (ofc *osFeatureCollector) recordFeaturesFromModules(modules []system.Module
 }
 
 func (ofc *osFeatureCollector) collect() {
+	if ofc.osFeature == nil {
+		return
+	}
 	cmdlineArgs, err := system.CmdlineArgs()
 	if err != nil {
 		glog.Fatalf("Error retrieving cmdline args: %v", err)

--- a/pkg/systemstatsmonitor/osfeature_collector.go
+++ b/pkg/systemstatsmonitor/osfeature_collector.go
@@ -142,7 +142,7 @@ func (ofc *osFeatureCollector) recordFeaturesFromModules(modules []system.Module
 }
 
 func (ofc *osFeatureCollector) collect() {
-	if ofc.osFeature == nil {
+	if ofc == nil || ofc.osFeature == nil {
 		return
 	}
 	cmdlineArgs, err := system.CmdlineArgs()

--- a/pkg/util/metrics/metric.go
+++ b/pkg/util/metrics/metric.go
@@ -42,6 +42,10 @@ const (
 	MemoryUnevictableUsedID MetricID = "memory/unevictable_used"
 	MemoryDirtyUsedID       MetricID = "memory/dirty_used"
 	OSFeatureID             MetricID = "system/os_feature"
+	SystemProcessesTotal    MetricID = "system/processes_total"
+	SystemProcsRunning      MetricID = "system/procs_running"
+	SystemProcsBlocked      MetricID = "system/procs_blocked"
+	SystemInterruptsTotal   MetricID = "system/interrupts_total"
 )
 
 var MetricMap MetricMapping


### PR DESCRIPTION
Tested on a COS VM:

```
$ curl -s localhost:20257/metrics | grep "^system_"
system_interrupts_total{kernel_version="5.4.49+",os_version="cos 85-13310.1041.24"} 8.759236e+07
system_processes_total{kernel_version="5.4.49+",os_version="cos 85-13310.1041.24"} 692506
system_procs_blocked{kernel_version="5.4.49+",os_version="cos 85-13310.1041.24"} 0
system_procs_running{kernel_version="5.4.49+",os_version="cos 85-13310.1041.24"} 2
```