### PR TITLE
add metric for per-cpu, per-stage timing

### DIFF
--- a/config/system-stats-monitor.json
+++ b/config/system-stats-monitor.json
@@ -1,99 +1,102 @@
 {
-	"cpu": {
-		"metricsConfigs": {
-			"cpu/runnable_task_count": {
-				"displayName": "cpu/runnable_task_count"
-			},
-			"cpu/usage_time": {
-				"displayName": "cpu/usage_time"
-			},
-			"cpu/load_1m": {
-				"displayName": "cpu/load_1m"
-			},
-			"cpu/load_5m": {
-				"displayName": "cpu/load_5m"
-			},
-			"cpu/load_15m": {
-				"displayName": "cpu/load_15m"
-			},
-			"system/processes_total": {
-				"displayName": "system/processes_total"
-			},
-			"system/procs_running": {
-				"displayName": "system/procs_running"
-			},
-			"system/procs_blocked": {
-				"displayName": "system/procs_blocked"
-			},
-			"system/interrupts_total": {
-				"displayName": "system/interrupts_total"
-			}
-		}
-	},
-	"disk": {
-		"metricsConfigs": {
-			"disk/io_time": {
-				"displayName": "disk/io_time"
-			},
-			"disk/weighted_io": {
-				"displayName": "disk/weighted_io"
-			},
-			"disk/avg_queue_len": {
-				"displayName": "disk/avg_queue_len"
-			},
-			"disk/operation_count": {
-				"displayName": "disk/operation_count"
-			},
-			"disk/merged_operation_count": {
-				"displayName": "disk/merged_operation_count"
-			},
-			"disk/operation_bytes_count": {
-				"displayName": "disk/operation_bytes_count"
-			},
-			"disk/operation_time": {
-				"displayName": "disk/operation_time"
-			},
-			"disk/bytes_used": {
-				"displayName": "disk/bytes_used"
-			}
-		},
-		"includeRootBlk": true,
-		"includeAllAttachedBlk": true,
-		"lsblkTimeout": "5s"
-	},
-	"host": {
-		"metricsConfigs": {
-			"host/uptime": {
-				"displayName": "host/uptime"
-			}
-		}
-	},
-	"memory": {
-		"metricsConfigs": {
-			"memory/bytes_used": {
-				"displayName": "memory/bytes_used"
-			},
-			"memory/anonymous_used": {
-				"displayName": "memory/anonymous_used"
-			},
-			"memory/page_cache_used": {
-				"displayName": "memory/page_cache_used"
-			},
-			"memory/unevictable_used": {
-				"displayName": "memory/unevictable_used"
-			},
-			"memory/dirty_used": {
-				"displayName": "memory/dirty_used"
-			}
-		}
-	},
-	"osFeature": {
-		"metricsConfigs": {
-			"system/os_feature": {
-				"displayName": "system/os_feature"
-			}
-		},
-		"KnownModulesConfigPath": "config/guestosconfig/known-modules.json"
-	},
-	"invokeInterval": "60s"
+  "cpu": {
+    "metricsConfigs": {
+      "cpu/load_15m": {
+        "displayName": "cpu/load_15m"
+      },
+      "cpu/load_1m": {
+        "displayName": "cpu/load_1m"
+      },
+      "cpu/load_5m": {
+        "displayName": "cpu/load_5m"
+      },
+      "cpu/runnable_task_count": {
+        "displayName": "cpu/runnable_task_count"
+      },
+      "cpu/usage_time": {
+        "displayName": "cpu/usage_time"
+      },
+      "system/cpu_stat": {
+        "displayName": "system/cpu_stat"
+      },
+      "system/interrupts_total": {
+        "displayName": "system/interrupts_total"
+      },
+      "system/processes_total": {
+        "displayName": "system/processes_total"
+      },
+      "system/procs_blocked": {
+        "displayName": "system/procs_blocked"
+      },
+      "system/procs_running": {
+        "displayName": "system/procs_running"
+      }
+    }
+  },
+  "disk": {
+    "includeAllAttachedBlk": true,
+    "includeRootBlk": true,
+    "lsblkTimeout": "5s",
+    "metricsConfigs": {
+      "disk/avg_queue_len": {
+        "displayName": "disk/avg_queue_len"
+      },
+      "disk/bytes_used": {
+        "displayName": "disk/bytes_used"
+      },
+      "disk/io_time": {
+        "displayName": "disk/io_time"
+      },
+      "disk/merged_operation_count": {
+        "displayName": "disk/merged_operation_count"
+      },
+      "disk/operation_bytes_count": {
+        "displayName": "disk/operation_bytes_count"
+      },
+      "disk/operation_count": {
+        "displayName": "disk/operation_count"
+      },
+      "disk/operation_time": {
+        "displayName": "disk/operation_time"
+      },
+      "disk/weighted_io": {
+        "displayName": "disk/weighted_io"
+      }
+    }
+  },
+  "host": {
+    "metricsConfigs": {
+      "host/uptime": {
+        "displayName": "host/uptime"
+      }
+    }
+  },
+  "invokeInterval": "60s",
+  "memory": {
+    "metricsConfigs": {
+      "memory/anonymous_used": {
+        "displayName": "memory/anonymous_used"
+      },
+      "memory/bytes_used": {
+        "displayName": "memory/bytes_used"
+      },
+      "memory/dirty_used": {
+        "displayName": "memory/dirty_used"
+      },
+      "memory/page_cache_used": {
+        "displayName": "memory/page_cache_used"
+      },
+      "memory/unevictable_used": {
+        "displayName": "memory/unevictable_used"
+      }
+    }
+  },
+  "osFeature": {
+    "KnownModulesConfigPath": "config/guestosconfig/known-modules.json",
+    "metricsConfigs": {
+      "system/os_feature": {
+        "displayName": "system/os_feature"
+      }
+    }
+  }
 }

--- a/pkg/exporters/stackdriver/stackdriver_exporter.go
+++ b/pkg/exporters/stackdriver/stackdriver_exporter.go
@@ -73,6 +73,7 @@ var NPDMetricToSDMetric = map[metrics.MetricID]string{
 	metrics.SystemProcsRunning:      "kubernetes.io/internal/node/guest/system/procs_running",
 	metrics.SystemProcsBlocked:      "kubernetes.io/internal/node/guest/system/procs_blocked",
 	metrics.SystemInterruptsTotal:   "kubernetes.io/internal/node/guest/system/interrupts_total",
+	metrics.SystemCPUStat:           "kubernetes.io/internal/node/guest/system/cpu_stat",
 	metrics.NetDevRxBytes:           "kubernetes.io/internal/node/guest/net/rx_bytes",
 	metrics.NetDevRxPackets:         "kubernetes.io/internal/node/guest/net/rx_packets",
 	metrics.NetDevRxErrors:          "kubernetes.io/internal/node/guest/net/rx_errors",

--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -32,6 +32,7 @@ Below metrics are collected from `cpu` component:
 * `system/procs_running`: Number of processes currently running.
 * `system/procs_blocked`: Number of processes currently blocked.
 * `system/interrupts_total`: Total number of interrupts serviced (cumulative).
+* `system/cpu_stats`: Cumulative time each cpu spent in various stages. Collected from `/proc/stats`. Has a label for `cpu` and `stage`.
 
 [/proc doc]: http://man7.org/linux/man-pages/man5/proc.5.html
 

--- a/pkg/systemstatsmonitor/labels.go
+++ b/pkg/systemstatsmonitor/labels.go
@@ -45,3 +45,9 @@ const kernelVersionLabel = "kernel_version"
 
 // interfaceNameLabel labels the network interface name
 const interfaceNameLabel = "interface_name"
+
+// cpuLabel labels the CPU (eg "cpu0")
+const cpuLabel = "cpu"
+
+// stageLabel labels the stage according to the kernel where CPU time was spent
+const stageLabel = "stage"

--- a/pkg/util/metrics/metric.go
+++ b/pkg/util/metrics/metric.go
@@ -46,6 +46,7 @@ const (
 	SystemProcsRunning      MetricID = "system/procs_running"
 	SystemProcsBlocked      MetricID = "system/procs_blocked"
 	SystemInterruptsTotal   MetricID = "system/interrupts_total"
+	SystemCPUStat           MetricID = "system/cpu_stat"
 	NetDevRxBytes           MetricID = "net/rx_bytes"
 	NetDevRxPackets         MetricID = "net/rx_packets"
 	NetDevRxErrors          MetricID = "net/rx_errors"


### PR DESCRIPTION
Tested on a COS VM:

```
$ curl -s localhost:20257/metrics  | grep -i ^system_cpu_stat
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="guest"} 0
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="guestNice"} 0
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="iRQ"} 0
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="idle"} 226616.13
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="iowait"} 23.92
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="nice"} 63.08
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="softIRQ"} 100.91
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="steal"} 67.03999999999999
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="system"} 2134.91
system_cpu_stat{cpu="cpu0",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="user"} 5909.54
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="guest"} 0
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="guestNice"} 0
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="iRQ"} 0
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="idle"} 226315.40000000002
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="iowait"} 339.48
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="nice"} 63.510000000000005
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="softIRQ"} 102.99
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="steal"} 67.47
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="system"} 2167.6800000000003
system_cpu_stat{cpu="cpu1",kernel_version="5.4.49+",os_version="cos 85-13310.1041.24",stage="user"} 5827.360000000001
```