### PR TITLE
Update image path in deployment yaml

### DIFF
--- a/deployment/node-problem-detector.yaml
+++ b/deployment/node-problem-detector.yaml
@@ -29,7 +29,7 @@ spec:
         - /node-problem-detector
         - --logtostderr
         - --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json
-        image: k8s.gcr.io/node-problem-detector:v0.8.1
+        image: k8s.gcr.io/node-problem-detector/node-problem-detector:v0.8.6
         resources:
           limits:
             cpu: 10m


### PR DESCRIPTION
The image location for node-problem-detector has moved under a
subdirectory now. The deployment config wasn't updates, so those using
the provided node-problem-detector.yaml file directly would end up with
ErrImagePull errors.

This updates the yaml to point to the new location and the latest
release.

Closes: #460 