### PR TITLE
Allow building on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
 # support needs libsystemd-dev or libsystemd-journal-dev.
 ENABLE_JOURNALD?=1
 
-ifeq ($(shell uname -s 2>/dev/null), Darwin)
+ifeq ($(go env GOHOSTOS), darwin)
+ENABLE_JOURNALD=0
+else ifeq ($(go env GOHOSTOS), windows)
 ENABLE_JOURNALD=0
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
 # support needs libsystemd-dev or libsystemd-journal-dev.
 ENABLE_JOURNALD?=1
 
+ifeq ($(shell uname -s 2>/dev/null), Darwin)
+ENABLE_JOURNALD=0
+endif
+
 # TODO(random-liu): Support different architectures.
 # The debian-base:v1.0.0 image built from kubernetes repository is based on
 # Debian Stretch. It includes systemd 232 with support for both +XZ and +LZ4


### PR DESCRIPTION
Journald is not available on mac. To allow building the rest of the
project while working on a mac, use the same flag as the Windows build
to skip inclusion of journald.