### PR TITLE
improvement health-checker

### DIFF
--- a/cmd/healthchecker/options/options.go
+++ b/cmd/healthchecker/options/options.go
@@ -40,6 +40,7 @@ type HealthCheckerOptions struct {
 	CriCtlPath         string
 	CriSocketPath      string
 	CoolDownTime       time.Duration
+	LoopBackTime       time.Duration
 	HealthCheckTimeout time.Duration
 	LogPatterns        types.LogPatternFlag
 }
@@ -63,6 +64,8 @@ func (hco *HealthCheckerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The path to the cri socket. Used with crictl to specify the socket path.")
 	fs.DurationVar(&hco.CoolDownTime, "cooldown-time", types.DefaultCoolDownTime,
 		"The duration to wait for the service to be up before attempting repair.")
+	fs.DurationVar(&hco.LoopBackTime, "loopback-time", types.DefaultLoopBackTime,
+		"The duration to loop back, if it is 0, health-check will check from start time.")
 	fs.DurationVar(&hco.HealthCheckTimeout, "health-check-timeout", types.DefaultHealthCheckTimeout,
 		"The time to wait before marking the component as unhealthy.")
 	fs.Var(&hco.LogPatterns, "log-pattern",

--- a/config/health-checker-kubelet.json
+++ b/config/health-checker-kubelet.json
@@ -25,6 +25,7 @@
         "--component=kubelet",
         "--enable-repair=true",
         "--cooldown-time=1m",
+        "--loopback-time=0",
         "--health-check-timeout=10s"
       ],
       "timeout": "3m"

--- a/deployment/node-problem-detector-healthchecker.yaml
+++ b/deployment/node-problem-detector-healthchecker.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-problem-detector
+  namespace: kube-system
+  labels:
+    app: node-problem-detector
+spec:
+  selector:
+    matchLabels:
+      app: node-problem-detector
+  template:
+    metadata:
+      labels:
+        app: node-problem-detector
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+      containers:
+      - name: node-problem-detector
+        command:
+        - /node-problem-detector
+        - --logtostderr
+        - --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json
+        - --config.custom-plugin-monitor=/config/health-checker-kubelet.json
+        image: k8s.gcr.io/node-problem-detector/node-problem-detector:v0.8.6
+        resources:
+          limits:
+            cpu: 10m
+            memory: 80Mi
+          requests:
+            cpu: 10m
+            memory: 80Mi
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: log
+          mountPath: /var/log
+          readOnly: true
+        - name: kmsg
+          mountPath: /dev/kmsg
+          readOnly: true
+        # Make sure node problem detector is in the same timezone
+        # with the host.
+        - name: localtime
+          mountPath: /etc/localtime
+          readOnly: true
+        - name: config
+          mountPath: /config
+          readOnly: true
+        - mountPath: /etc/machine-id
+          name: machine-id
+          readOnly: true
+        - mountPath: /run/systemd/system
+          name: systemd
+        - mountPath: /var/run/dbus/
+          name: dbus
+          mountPropagation: Bidirectional
+      volumes:
+      - name: log
+        # Config `log` to your system log directory
+        hostPath:
+          path: /var/log/
+      - name: kmsg
+        hostPath:
+          path: /dev/kmsg
+      - name: localtime
+        hostPath:
+          path: /etc/localtime
+      - name: config
+        configMap:
+          name: node-problem-detector-config
+          items:
+          - key: kernel-monitor.json
+            path: kernel-monitor.json
+          - key: docker-monitor.json
+            path: docker-monitor.json
+      - name: machine-id
+        hostPath:
+          path: /etc/machine-id
+          type: "File"
+      - name: systemd
+        hostPath:
+          path: /run/systemd/system/
+          type: ""
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus/
+          type: ""

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	DefaultLoopBackTime       = 0 * time.Minute
 	DefaultCoolDownTime       = 2 * time.Minute
 	DefaultHealthCheckTimeout = 10 * time.Second
 	CmdTimeout                = 10 * time.Second


### PR DESCRIPTION
/kind bug
1. add loopbacktime to reduce time of journalctl call
If use start time of kubelet as the journalctl, it could be take too much time to call. 
I add loopkbacktime to set loop back time for journalctl, if not set or set = 0, it uses start time directly, else it use loopkbacktime.

2. fix timelayout for all timezones
Different nodes usally use different time zone:
`[root@kubernetes-master-505-pkshx-4589367 software]# systemctl show kubelet --property=InactiveExitTimestamp
InactiveExitTimestamp=Wed 2021-03-10 06:05:51 PST`
I think npd doesn't need to care about the timezone if can ensure timezone is agreement with runtime/kubelet and journald.
----
this point has been fixed by https://github.com/kubernetes/node-problem-detector/pull/558

3. add npd health-checker deploy file
Many users reflect that can not use health-checker because use the wrong specs: [!439](https://github.com/kubernetes/node-problem-detector/issues/439), [!540](https://github.com/kubernetes/node-problem-detector/issues/540), [!482](https://github.com/kubernetes/node-problem-detector/issues/482). I thinks this commit can fix these issues.