### PR TITLE
Update node-problem-detector.yaml

### DIFF
--- a/deployment/node-problem-detector.yaml
+++ b/deployment/node-problem-detector.yaml
@@ -29,7 +29,7 @@ spec:
         - /node-problem-detector
         - --logtostderr
         - --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json
-        image: k8s.gcr.io/node-problem-detector/node-problem-detector:v0.8.6
+        image: k8s.gcr.io/node-problem-detector/node-problem-detector:v0.8.7
         resources:
           limits:
             cpu: 10m


### PR DESCRIPTION
Hi All,

I was having a timeout issue when I was trying to use a custom plugin using NPD v0.8.6. I noticed there is a new version with the fix. 

The Manifest should have the last available version.