### PR TITLE
Detect when container process fails to start

### DIFF
--- a/config/windows-containerd-monitor-filelog.json
+++ b/config/windows-containerd-monitor-filelog.json
@@ -13,13 +13,13 @@
 	"rules": [
 		{
 			"type": "temporary",
-			"reason": "MissingPigz",
-			"pattern": "unpigz not found.*"
+			"reason": "ContainerCreationFailed",
+			"pattern": ".*failed to create containerd container.*error unpacking image.*wrong diff id calculated on extraction.*"
 		},
 		{
 			"type": "temporary",
-			"reason": "IncompatibleContainer",
-			"pattern": ".*CreateComputeSystem.*"
+			"reason": "CorruptContainerImageLayer",
+			"pattern": ".*failed to pull and unpack image.*failed to extract layer.*archive/tar: invalid tar header.*"
 		}
 	]
 }


### PR DESCRIPTION
This change adds another rule to detect from the containerd log file. It will detect when a containerD fails to start a process due to a corrupt image.

Sample logs:
**"reason": "ContainerDContainerCreationFailed":**
`time="2021-04-28T00:01:18.901493400Z" level=error msg="CreateContainer within sandbox \"ce6f3a2bc2a13b86be77417271d4f5b72210418eb2277fd9bc27622cfbe34012\" for &ContainerMetadata{Name:testimage,Attempt:0,} failed" error="failed to create containerd container: error unpacking image: wrong diff id calculated on extraction \"sha256:9bddaf2b9de37115dd4657ce3d726e3d794158da99e107fbeb15df4c1ecc648b\""
`

**"reason": "CorruptContainerImageLayer":**
`time="2021-04-28T00:14:50.181394800Z" level=error msg="PullImage \"gcr.io/jeremyje/chatterbox:head\" failed" error="failed to pull and unpack image \"gcr.io/jeremyje/chatterbox:head\": failed to extract layer sha256:cecc319109e39102773e8154e23ac2c672402c9e4c7e1a801a62208ddf9407c4: archive/tar: invalid tar header: unknown"`

_The following errors are not included to be detected either because they are errors that we do not want to detect to falsely identify that the node is unhealthy._ 
`time="2021-04-28T00:14:15.311477800Z" level=error msg="PullImage \"gcr.io/jeremyje/chatterbox:head\" failed" error="failed to pull and unpack image \"gcr.io/jeremyje/chatterbox:head\": failed to copy: httpReaderSeeker: failed open: unexpected status code https://gcr.io/v2/jeremyje/chatterbox/blobs/sha256:5675a081083222834c96d41259098a1ae95d2822f5dd72f3e7d66cc4ef8d0f7ec: 400 Bad Request - Server message: unknown: 'digest' parameter is not a valid digest 'sha256:5675a081083222834c96d41259098a1ae95d2822f5dd72f3e7d66cc4ef8d0f7ec'."
`

`time="2021-04-28T18:06:11.499594200Z" level=error msg="PullImage \"gcr.io/michelletamdua\" failed" error="failed to pull and unpack image \"gcr.io/michelletamdua:latest\": failed to resolve reference \"gcr.io/michelletamdua:latest\": unexpected status code [manifests latest]: 400 Bad Request"`

`time="2021-04-28T18:05:40.152050900Z" level=error msg="PullImage \"gcr.io/michelletandya-gke-dev/gowiki:v1\" failed" error="failed to pull and unpack image \"gcr.io/michelletandya-gke-dev/gowiki:v1\": failed to resolve reference \"gcr.io/michelletandya-gke-dev/gowiki:v1\": unexpected status code [manifests v1]: 401 Unauthorized"
`
`
time="2021-04-22T21:39:40.972814800Z" level=error msg="StartContainer for \"8559f453e383cfc3dfa960c4550bc1fd4a3809b20cbfd1a121f9d71c666cc5ce\" failed" error="failed to start containerd task \"8559f453e383cfc3dfa960c4550bc1fd4a3809b20cbfd1a121f9d71c666cc5ce\": hcsshim::System::CreateProcess 8559f453e383cfc3dfa960c4550bc1fd4a3809b20cbfd1a121f9d71c666cc5ce: The system cannot find the file specified.\n(extra info: {\"CommandLine\":\"/app/chatterbox.exe -addr :8080\",\"User\":\"ContainerUser\",\"WorkingDirectory\":\"C:\\\\\",\"Environment\":{\"KUBERNETES_PORT\":\"tcp://10.0.0.1:443\",\"KUBERNETES_PORT_443_TCP\":\"tcp://10.0.0.1:443\",\"KUBERNETES_PORT_443_TCP_ADDR\":\"10.0.0.1\",\"KUBERNETES_PORT_443_TCP_PORT\":\"443\",\"KUBERNETES_PORT_443_TCP_PROTO\":\"tcp\",\"KUBERNETES_SERVICE_HOST\":\"10.0.0.1\",\"KUBERNETES_SERVICE_PORT\":\"443\",\"KUBERNETES_SERVICE_PORT_HTTPS\":\"443\",\"PATH\":\"c:\\\\Windows\\\\System32;c:\\\\Windows\"},\"CreateStdOutPipe\":true,\"CreateStdErrPipe\":true}): unknown"
`

