### PR TITLE
Add healthChecker functionality for kube-proxy service

### DIFF
--- a/cmd/healthchecker/options/options.go
+++ b/cmd/healthchecker/options/options.go
@@ -47,7 +47,7 @@ type HealthCheckerOptions struct {
 // AddFlags adds health checker command line options to pflag.
 func (hco *HealthCheckerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&hco.Component, "component", types.KubeletComponent,
-		"The component to check health for. Supports kubelet, docker and cri")
+		"The component to check health for. Supports kubelet, docker, kube-proxy, and cri")
 	// Deprecated: For backward compatibility on linux environment. Going forward "service" will be used instead of systemd-service
 	if runtime.GOOS == "linux" {
 		fs.MarkDeprecated("systemd-service", "please use --service flag instead")
@@ -73,8 +73,9 @@ func (hco *HealthCheckerOptions) AddFlags(fs *pflag.FlagSet) {
 // Returns error if invalid, nil otherwise.
 func (hco *HealthCheckerOptions) IsValid() error {
 	// Make sure the component specified is valid.
-	if hco.Component != types.KubeletComponent && hco.Component != types.DockerComponent && hco.Component != types.CRIComponent {
-		return fmt.Errorf("the component specified is not supported. Supported components are : <kubelet/docker/cri>")
+	if hco.Component != types.KubeletComponent && hco.Component != types.DockerComponent &&
+		hco.Component != types.CRIComponent && hco.Component != types.KubeProxyComponent {
+		return fmt.Errorf("the component specified is not supported. Supported components are : <kubelet/docker/cri/kube-proxy>")
 	}
 	// Make sure the service is specified if repair is enabled.
 	if hco.EnableRepair && hco.Service == "" {

--- a/config/windows-health-checker-kubeproxy.json
+++ b/config/windows-health-checker-kubeproxy.json
@@ -1,0 +1,34 @@
+{
+    "plugin": "custom",
+    "pluginConfig": {
+      "invoke_interval": "10s",
+      "timeout": "3m",
+      "max_output_length": 80,
+      "concurrency": 1
+    },
+    "source": "health-checker",
+    "metricsReporting": true,
+    "conditions": [
+      {
+        "type": "KubeProxyUnhealthy",
+        "reason": "KubeProxyIsHealthy",
+        "message": "kube-proxy on the node is functioning properly"
+      }
+    ],
+    "rules": [
+      {
+        "type": "permanent",
+        "condition": "KubeProxyUnhealthy",
+        "reason": "KubeProxyUnhealthy",
+        "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
+        "args": [
+          "--component=kube-proxy",
+          "--enable-repair=true",
+          "--cooldown-time=1m",
+          "--health-check-timeout=10s"
+        ],
+        "timeout": "3m"
+      }
+    ]
+  }
+  

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -30,12 +30,14 @@ const (
 	CmdTimeout                = 10 * time.Second
 	LogParsingTimeLayout      = "2006-01-02 15:04:05"
 
-	KubeletComponent  = "kubelet"
-	CRIComponent      = "cri"
-	DockerComponent   = "docker"
-	ContainerdService = "containerd"
+	KubeletComponent   = "kubelet"
+	CRIComponent       = "cri"
+	DockerComponent    = "docker"
+	ContainerdService  = "containerd"
+	KubeProxyComponent = "kube-proxy"
 
-	KubeletHealthCheckEndpoint = "http://127.0.0.1:10248/healthz"
+	KubeletHealthCheckEndpoint   = "http://127.0.0.1:10248/healthz"
+	KubeProxyHealthCheckEndpoint = "http://127.0.0.1:10256/healthz"
 
 	LogPatternFlagSeparator = ":"
 )


### PR DESCRIPTION
There have been some customer complaints that on windows node start ups, that when kube-proxy fails to start, some pods pods were entering into a crashloop state as services were inaccessible. Adding functionality to detect when kube-proxy is down, can attempt to repair the service and prevent pods from entering into a crashloop state. 

