### PR TITLE
Add windows defender problem detection custom plugin

### DIFF
--- a/config/plugin/windows_defender_problem.ps1
+++ b/config/plugin/windows_defender_problem.ps1
@@ -1,0 +1,10 @@
+# This plugin checks to see if windows defender detects any threats to the node.
+
+$windowsDefenderThreats = (Get-MpThreat | Where-Object {$_.IsActive -or $_.DidThreatExecute})
+
+if ($windowsDefenderThreats.length -ne 0) {
+    Write-Host $windowsDefenderThreats
+    exit 1
+} else {
+    exit 0
+}

--- a/config/windows-defender-monitor.json
+++ b/config/windows-defender-monitor.json
@@ -1,0 +1,21 @@
+{
+    "plugin": "custom",
+    "pluginConfig": {
+      "invoke_interval": "10m",
+      "timeout": "5s",
+      "max_output_length": 80,
+      "concurrency": 3
+    },
+    "source": "windows-defender-custom-plugin-monitor",
+    "metricsReporting": true,
+    "conditions": [],
+    "rules": [
+      {
+        "type": "temporary",
+        "reason": "WindowsDefenderThreatsDetected",
+        "path": "./config/plugin/windows_defender_problem.ps1",
+        "timeout": "3s"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Windows Defender helps detect any malware, viruses, etc on a windows node. If windows defender detects any threats, we should indicate that there is an issue on the node. So, a custom plugin has been added to monitor this. 

`Get-MpThreat` currently will output an empty string if no threats are detected. Anything string output that is returned will indicate that there is a threat.
If a threat has been detected, we can check if that threat had been executed or is currently active to determine the health of out node. If either is true, we return with exit 1 to indicate a problem detected from windows defender
```
CategoryID       : 27
DidThreatExecute : False
IsActive         : False
Resources        : {file:_C:\Users\michelletandya\Downloads\PotentiallyUnwanted.exe, file:_C:\Users\michelletandya\Downloads\potentiallyUnwanted2.exe,
                   file:_C:\Users\michelletandya\Downloads\potentiallyUnwanted2.exe, file:_C:\Users\michelletandya\Downloads\PotentiallyUnwanted (1).exe}
RollupStatus     : 33
SchemaVersion    : 1.0.0.0
SeverityID       : 5
ThreatID         : 224688
ThreatName       : PUA:Win32/EICAR_Test_File
TypeID           : 0
PSComputerName   :
```