### PR TITLE
Add csi-proxy monitoring to health checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,9 @@ $(NPD_NAME_VERSION)-%.tar.gz: $(ALL_BINARIES) test/e2e-install.sh
 	(cd output/$*/ && tar -zcvf ../../$@ *)
 	sha512sum $@ > $@.sha512
 
+windows-binaries: ENABLE_JOURNALD=0
+windows-binaries: $(foreach binary, $(BINARIES), output/windows_amd64/$(binary).exe)
+
 build-binaries: $(ALL_BINARIES)
 
 build-container: build-binaries Dockerfile

--- a/cmd/healthchecker/options/options_linux.go
+++ b/cmd/healthchecker/options/options_linux.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+const (
+	supportedComponentsFlagMessage = "The component to check health for. Supports kubelet, docker, kube-proxy, and cri"
+	supportedServicesFlagMessage   = "The underlying service responsible for the component. Set to the corresponding component for docker and kubelet, containerd for cri."
+	validComponentMessage          = "the component specified is not supported. Supported components are: <kubelet/docker/cri/kube-proxy>"
+)

--- a/cmd/healthchecker/options/options_windows.go
+++ b/cmd/healthchecker/options/options_windows.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2021 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+const (
+	supportedComponentsFlagMessage = "The component to check health for. Supports csiproxy, kubelet, docker, kube-proxy, and cri"
+	supportedServicesFlagMessage   = "The underlying service responsible for the component. Set to the corresponding component for csiproxy, docker, kubelet, containerd for cri."
+	validComponentMessage          = "the component specified is not supported. Supported components are: <kubelet/docker/cri/kube-proxy/csi-proxy>"
+)

--- a/config/windows-health-checker-csiproxy.json
+++ b/config/windows-health-checker-csiproxy.json
@@ -1,0 +1,35 @@
+{
+    "plugin": "custom",
+    "pluginConfig": {
+      "invoke_interval": "10s",
+      "timeout": "3m",
+      "max_output_length": 80,
+      "concurrency": 1
+    },
+    "source": "health-checker",
+    "metricsReporting": true,
+    "conditions": [
+      {
+        "type": "CsiProxyUnhealthy",
+        "reason": "CsiProxyIsHealthy",
+        "message": "Csi-Proxy on the node is functioning properly"
+      }
+    ],
+    "rules": [
+      {
+        "type": "permanent",
+        "condition": "CsiProxyUnhealthy",
+        "reason": "CsiProxyUnhealthy",
+        "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
+        "args": [
+          "--component=csi-proxy",
+          "--enable-repair=true",
+          "--service=csiproxy",
+          "--cooldown-time=2m",
+          "--health-check-timeout=60s"
+        ],
+        "timeout": "3m"
+      }
+    ]
+  }
+  

--- a/pkg/healthchecker/health_checker_windows.go
+++ b/pkg/healthchecker/health_checker_windows.go
@@ -85,6 +85,13 @@ func getHealthCheckFunc(hco *options.HealthCheckerOptions) func() (bool, error) 
 			}
 			return true, nil
 		}
+	case types.CsiProxyComponent:
+		return func() (bool, error) {
+			if _, err := powershell("Get-Process", types.CsiProxyComponent); err != nil {
+				return false, nil
+			}
+			return true, nil
+		}
 	}
 	return nil
 }

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -35,6 +35,7 @@ const (
 	DockerComponent    = "docker"
 	ContainerdService  = "containerd"
 	KubeProxyComponent = "kube-proxy"
+	CsiProxyComponent  = "csi-proxy"
 
 	KubeletHealthCheckEndpoint   = "http://127.0.0.1:10248/healthz"
 	KubeProxyHealthCheckEndpoint = "http://127.0.0.1:10256/healthz"


### PR DESCRIPTION
CSI-Proxy is being integrated on windows nodes, running as a windows service. It is used to help CSI Node Plugin interact with the node given that privileged containers are not yet supported on Windows. This change monitors to ensure that csi-proxy is running and available through NPD's health checker.


[#461](https://github.com/kubernetes/node-problem-detector/issues/461)