### PR TITLE
Added arm64 targets for linux binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
  - docker
 before_install:
  - sudo apt-get -qq update
- - sudo apt-get install -y libsystemd-dev
+ - sudo apt-get install -y libsystemd-dev libc6-dev-arm64-cross gcc-aarch64-linux-gnu
 install:
  - mkdir -p $HOME/gopath/src/k8s.io
  - mv $TRAVIS_BUILD_DIR $HOME/gopath/src/k8s.io/node-problem-detector

--- a/README.md
+++ b/README.md
@@ -137,12 +137,16 @@ For example, to run without auth, use the following config:
 
 ## Build Image
 
+* Install development dependencies for `libsystemd` and the ARM GCC toolchain
+  * Debian: `apt install libsystemd-dev gcc-aarch64-linux-gnu`
+  * Ubuntu: `apt install libsystemd-journal-dev gcc-aarch64-linux-gnu`
+
 * `go get` or `git clone` node-problem-detector repo into `$GOPATH/src/k8s.io` or `$GOROOT/src/k8s.io`
 with one of the below directions:
   * `cd $GOPATH/src/k8s.io && git clone git@github.com:kubernetes/node-problem-detector.git`
   * `cd $GOPATH/src/k8s.io && go get k8s.io/node-problem-detector`
 
-* run `make` in the top directory. It will:
+* Run `make` in the top directory. It will:
   * Build the binary.
   * Build the docker image. The binary and `config/` are copied into the docker image.
 
@@ -157,11 +161,6 @@ The above command will compile the node-problem-detector without [Custom Plugin 
 and [System Stats Monitor](https://github.com/kubernetes/node-problem-detector/tree/master/pkg/systemstatsmonitor).
 Check out the [Problem Daemon](https://github.com/kubernetes/node-problem-detector#problem-daemon) section
 to see how to disable each problem daemon during compilation time.
-
-**Note**:
-By default, node-problem-detector will be built with systemd support with the `make` command. This requires systemd develop files.
-You should download the systemd develop files first. For Ubuntu, the `libsystemd-journal-dev` package should
-be installed. For Debian, the `libsystemd-dev` package should be installed.
 
 ## Push Image
 

--- a/test/build.sh
+++ b/test/build.sh
@@ -65,7 +65,7 @@ function get-version() {
 
 function install-lib() {
   apt-get update
-  apt-get install -y libsystemd-dev
+  apt-get install -y libsystemd-dev gcc-aarch64-linux-gnu
   # Turn off go modules here, because we are not trying to install
   # ginkgo library/module. We are trying to install the ginkgo executable.
   GO111MODULE=off go get -v github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
This change adds support for arm64 targets for the linux binaries and an arm64 tarball target. See #135 

The existing `build-binaries`, `build-tar` targets now compile for arm64 in addition to amd64 on linux.

Thanks to @jeremyje for the multi-platform/os support (#545). It makes this change much simpler.