### PR TITLE
config/windows-defender-monitor.json

### DIFF
--- a/config/windows-defender-monitor.json
+++ b/config/windows-defender-monitor.json
@@ -13,7 +13,7 @@
       {
         "type": "temporary",
         "reason": "WindowsDefenderThreatsDetected",
-        "path": "./config/plugin/windows_defender_problem.ps1",
+        "path": "C:\\etc\\kubernetes\\node-problem-detector\\config\\plugin\\windows_defender_problem.ps1",
         "timeout": "3s"
       }
     ]


### PR DESCRIPTION
Currently, the windows defender custom plugin path is a local reference. This needs to be updated to a full path location. 

https://github.com/kubernetes/node-problem-detector/issues/559