### PR TITLE
Bump image version from v1.0.0 to v.2.0.0 to fix some of the CVEs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 # The debian-base:v1.0.0 image built from kubernetes repository is based on
 # Debian Stretch. It includes systemd 232 with support for both +XZ and +LZ4
 # compression. +LZ4 is needed on some os distros such as COS.
-BASEIMAGE:=k8s.gcr.io/debian-base-amd64:v1.0.0
+BASEIMAGE:=k8s.gcr.io/debian-base-amd64:v2.0.0
 
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0


### PR DESCRIPTION
Bump image version from v1.0.0 to v.2.0.0 to fix some of the CVEs.