### PR TITLE
update CriCtl path for windows

### DIFF
--- a/pkg/healthchecker/types/types_windows.go
+++ b/pkg/healthchecker/types/types_windows.go
@@ -17,7 +17,7 @@ limitations under the License.
 package types
 
 const (
-	DefaultCriCtl        = "C:/node/crictl.exe"
+	DefaultCriCtl        = "C:/etc/kubernetes/node/bin/crictl.exe"
 	DefaultCriSocketPath = "npipe:////./pipe/containerd-containerd"
 	UptimeTimeLayout     = "Mon 02 Jan 2006 15:04:05 MST"
 	LogParsingTimeFormat = "yyyy-MM-dd HH:mm:ss"


### PR DESCRIPTION
Containerd is constantly being restarted due to NPD's healthchecker. The CriCtl path that it uses to detect the health of containerd is incorrect. This change updates the path for windows nodes to the correct path and will prevent containerD from restarting all the time.