### PR TITLE
Add HCS empty layer error reporting.

### DIFF
--- a/config/windows-containerd-monitor-filelog.json
+++ b/config/windows-containerd-monitor-filelog.json
@@ -20,6 +20,11 @@
 			"type": "temporary",
 			"reason": "CorruptContainerImageLayer",
 			"pattern": ".*failed to pull and unpack image.*failed to extract layer.*archive/tar: invalid tar header.*"
+		},
+		{
+			"type": "temporary",
+			"reason": "HCSEmptyLayerchain",
+			"pattern": ".*Failed to unmarshall layerchain json - invalid character '\\x00' looking for beginning of value*"
 		}
 	]
 }


### PR DESCRIPTION
This change adds detection for container errors that cause containers from starting. It's not clear why this happens yet as it's hard to reproduce and it also appears to impact future pods on the same node.

https://github.com/microsoft/service-fabric/issues/1146