### PR TITLE
Build multi-arch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ FROM ${BASEIMAGE}
 
 MAINTAINER Random Liu <lantaol@google.com>
 
-RUN clean-install util-linux libsystemd0 bash
+ARG PREINSTALL=true
+RUN if [ "$PREINSTALL" = "true" ] ; then clean-install util-linux libsystemd0 bash ; fi
 
 # Avoid symlink of /etc/localtime.
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true

--- a/Makefile
+++ b/Makefile
@@ -266,8 +266,12 @@ push-container: build-container
 push-container-multi-arch: build-binaries Dockerfile
 	gcloud auth configure-docker
 	docker buildx build \
-		--push --platform linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 \
-		-t $(IMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
+		--push \
+		--platform linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x \
+		-t $(IMAGE) \
+		--build-arg BASEIMAGE=debian:buster \
+		--build-arg LOGCOUNTER=$(LOGCOUNTER) \
+		--build-arg PREINSTALL=false .
 
 push-tar: build-tar
 	gsutil cp $(TARBALL) $(UPLOAD_PATH)/node-problem-detector/

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 .PHONY: all \
         vet fmt version test e2e-test \
         build-binaries build-container build-tar build \
-        docker-builder build-in-docker push-container push-tar push clean
+        docker-builder build-in-docker push-container push-container-multi-arch push-tar push clean
 
 all: build
 
@@ -262,6 +262,12 @@ build-in-docker: clean docker-builder
 push-container: build-container
 	gcloud auth configure-docker
 	docker push $(IMAGE)
+
+push-container-multi-arch: build-binaries Dockerfile
+	gcloud auth configure-docker
+	docker buildx build \
+		--push --platform linux/amd64,linux/arm/v7,linux/arm64,windows/amd64 \
+		-t $(IMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
 
 push-tar: build-tar
 	gsutil cp $(TARBALL) $(UPLOAD_PATH)/node-problem-detector/


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/node-problem-detector/issues/586 


Because `k8s.gcr.io/debian-base-amd64:v2.0.0` does not support multiple architectures, I use `debian:buster` instead.

buildx can not export multiple architectures image to docker, https://github.com/docker/buildx/issues/59 ,So we directly push the image to the registry


If you want to build this locally, make sure run the following command first , otherwise you may get a error `error: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")`

```
# run this before build locally 
# If you build this on Github Action, Add a step `docker/setup-buildx-action@v1` instead 
sudo docker buildx create --name builder --driver docker-container --driver-opt image=moby/buildkit:master
```



``` sh 
docker manifest inspect xinydev/node-problem-detector:v0.8.9

{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1368,
         "digest": "sha256:de9f30d2f0aea0b983db7d437a1d58cfd8daa7a2c264e7687687f31e87fd7826",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1368,
         "digest": "sha256:fb2e84e713932539deb10e5c2773a96c93b6cb334a01b05c60eee175b11a8d91",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1368,
         "digest": "sha256:b0dd91c795b9cb77aec2308d35086c80cb40a1690d02b964ff92f2e4cb7aa944",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1368,
         "digest": "sha256:9931eb4f416a94ae8d1cc9f501d06c23a9ec836e7df0b708cf95fc686f3a065c",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1368,
         "digest": "sha256:07a1bb3e16af6345b4985cf3c3d5ee77f899a725c8daba56ba884c1afeafd038",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```