### PR TITLE
Add vteratipally as a reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,9 +4,11 @@ reviewers:
   - andyxning
   - wangzhen127
   - xueweiz
+  - vteratipally
 approvers:
   - Random-Liu
   - dchen1107
   - andyxning
   - wangzhen127
   - xueweiz
+  - vteratipally

--- a/OWNERS
+++ b/OWNERS
@@ -11,4 +11,3 @@ approvers:
   - andyxning
   - wangzhen127
   - xueweiz
-  - vteratipally


### PR DESCRIPTION
Reopened PR ( https://github.com/kubernetes/node-problem-detector/pull/514) as it was stale for more than 30 days. 

* Member for at least 3 months
  * Joined Kubernetes in [December 18, 2020](https://github.com/kubernetes/org/issues/2331), https://github.com/kubernetes/org/pull/2393.
* Primary reviewer for at least 5 PRs to the codebase
  * Reviewed 6 PRs: https://github.com/kubernetes/node-problem-detector/pulls?q=reviewed-by%3Avteratipally+is%3Aclosed+is%3Apr+-author%3Avteratipally
* Reviewed or merged at least 20 substantial PRs to the codebase
  * I have submitted 20 PRs: https://github.com/kubernetes/node-problem-detector/pulls?q=is%3Apr+author%3Avteratipally+is%3Aclosed
* Knowledgeable about the codebase
  * Reviewed and participated in design discussions for gke-node-telemetry
  and knowledge transfers to new members to help contribute GKE Windows and GKE Node and Redis team. 
* Sponsored by a subproject approver
  * Requesting @Random-Liu 
  * With no objections from other approvers
* Done through PR to update the OWNERS file
  * https://github.com/kubernetes/node-problem-detector/pull/514
* May either self-nominate, be nominated by an approver in this subproject, or be nominated by a robot
  * Self nominating


