### PR TITLE
Update builder to go 1.16 and remove godep

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.11.0
+FROM golang:1.16.0
 LABEL maintainer="Andy Xie <andy.xning@gmail.com>"
 
 ENV GOPATH /gopath/
@@ -20,6 +20,4 @@ ENV PATH $GOPATH/bin:$PATH
 
 RUN apt-get update && apt-get --yes install libsystemd-dev
 RUN go version
-RUN go get github.com/tools/godep
-RUN godep version
 CMD ["/bin/bash"]


### PR DESCRIPTION
The built-in builder dockerfile is out of date, and does not successfully build a working Node Problem Detector binary.

This PR updates it to go 1.16 (the version currently used in Travis) and removes godep, which was removed back in #287.