### PR TITLE
Create cloudbuild file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,21 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 7200s
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:latest'
+    entrypoint: bash
+    env:
+    - PROW_GIT_TAG=$_GIT_TAG
+    - PULL_BASE_REF=$_PULL_BASE_REF
+    - VERSION=$_PULL_BASE_REF
+    args:
+    - -c
+    - |
+      echo "Building/Pushing NPD containers"
+      make push-container
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: 'PLACE_HOLDER'
+  _PULL_BASE_REF: 'master'


### PR DESCRIPTION
## What does this PR do?
Create file `cloudbuild.yaml`, which is required for [image pushing job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-node-problem-detector.yaml).

I took [kubernetes/dns](https://github.com/kubernetes/dns/blob/master/cloudbuild.yaml) as an example. Please let me know if there's anything that must be changed.

Closes https://github.com/kubernetes/test-infra/issues/23202