### PR TITLE
Update powershell command for uptime to help efficiency

### DIFF
--- a/pkg/healthchecker/health_checker_windows.go
+++ b/pkg/healthchecker/health_checker_windows.go
@@ -33,12 +33,19 @@ import (
 // getUptimeFunc returns the time for which the given service has been running.
 func getUptimeFunc(service string) func() (time.Duration, error) {
 	return func() (time.Duration, error) {
-		// Using the WinEvent Log Objects to find the Service logs' time when the Service last entered running state.
+		// To attempt to calculate uptime more efficiently, we attempt to grab the process id to grab the start time.
+		// If the process id does not exist (meaning the service is not running for some reason), we will result to
+		// using the WinEvent Log Objects to find the Service logs' time when the Service last entered running state.
+		// In addition to filtering not by the logname=system we also filter on event id=7036 to reduce the number of
+		// entries the next command Where-Object will have to look through. id 7036 messages indicating a stopped or running service.
 		// The powershell command formats the TimeCreated of the event log in RFC1123Pattern.
 		// However, because the time library parser does not recognize the ',' in this RFC1123Pattern format,
 		// it is manually removed before parsing it using the UptimeTimeLayout.
-		getTimeCreatedCmd := "(Get-WinEvent -Logname System | Where-Object {$_.Message -Match '.*(" + service +
-			").*(running).*'} | Select-Object -Property TimeCreated -First 1 | foreach {$_.TimeCreated.ToString('R')} | Out-String).Trim()"
+		getTimeCreatedCmd := `$ProcessId = (Get-WMIObject -Class Win32_Service -Filter "Name='` + service + `'" | Select-Object -ExpandProperty ProcessId);` +
+			`if ([string]::IsNullOrEmpty($ProcessId) -or $ProcessId -eq 0) { (Get-WinEvent -FilterHashtable @{logname='system';id=7036} ` +
+			`| Where-Object {$_.Message -match '.*(` + service + `).*(running).*'}  | Select-Object -Property TimeCreated -First 1 | ` +
+			`foreach {$_.TimeCreated.ToString('R')} | Out-String).Trim() } else { (Get-Process -Id $ProcessId | Select starttime | ` +
+			`foreach {$_.starttime.ToString('R')} | Out-String).Trim() }`
 		out, err := powershell(getTimeCreatedCmd)
 		if err != nil {
 			return time.Duration(0), err


### PR DESCRIPTION
When uptime function is called, we make a powershell query to trace through all the WinEvents. To attempt to make this call a little efficient, we will attempt to grab the process ID of the service (if it is running) and query the starttime based off of that. This will prevent the extensive querying that we do when calling Get-WinEvent. This only takes care of the case if the service is still running and an issue is detected. 

If the Process ID does not exist and the service seems to have stopped running, then we will result to using the Get-WinEvent querying approach with an additional filter. I added an additional filter to filter not only by the logname=system but to also filter on event id=7036 to reduce the number of entries the next command `Where-Object` will have to look through. It seems that all messages indicating a stopped or running service will have the event id=7036. 