### PR TITLE
Ensure time is in Universal Time Zone to properly calculate uptime

### DIFF
--- a/pkg/healthchecker/health_checker_windows.go
+++ b/pkg/healthchecker/health_checker_windows.go
@@ -44,8 +44,8 @@ func getUptimeFunc(service string) func() (time.Duration, error) {
 		getTimeCreatedCmd := `$ProcessId = (Get-WMIObject -Class Win32_Service -Filter "Name='` + service + `'" | Select-Object -ExpandProperty ProcessId);` +
 			`if ([string]::IsNullOrEmpty($ProcessId) -or $ProcessId -eq 0) { (Get-WinEvent -FilterHashtable @{logname='system';id=7036} ` +
 			`| Where-Object {$_.Message -match '.*(` + service + `).*(running).*'}  | Select-Object -Property TimeCreated -First 1 | ` +
-			`foreach {$_.TimeCreated.ToString('R')} | Out-String).Trim() } else { (Get-Process -Id $ProcessId | Select starttime | ` +
-			`foreach {$_.starttime.ToString('R')} | Out-String).Trim() }`
+			`foreach {$_.TimeCreated.ToUniversalTime().ToString('R')} | Out-String).Trim() } else { (Get-Process -Id $ProcessId | Select starttime | ` +
+			`foreach {$_.starttime.ToUniversalTime().ToString('R')} | Out-String).Trim() }`
 		out, err := powershell(getTimeCreatedCmd)
 		if err != nil {
 			return time.Duration(0), err


### PR DESCRIPTION
An issue was found for Local time zones that are not using UTC where the uptime calculation was not calculated properly. Need to convert the start time to UTC so that the uptimeFunc can calculate the uptime correctly and will wait to repair only if uptime has exceeded cooldown period. 