### PR TITLE
Install systemd in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ${BASEIMAGE}
 
 MAINTAINER Random Liu <lantaol@google.com>
 
-RUN clean-install util-linux libsystemd0 bash
+RUN clean-install util-linux libsystemd0 bash curl systemd
 
 # Avoid symlink of /etc/localtime.
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM ${BASEIMAGE}
 
 MAINTAINER Random Liu <lantaol@google.com>
 
-RUN clean-install util-linux libsystemd0 bash curl systemd
+RUN clean-install util-linux libsystemd0 bash systemd
 
 # Avoid symlink of /etc/localtime.
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true


### PR DESCRIPTION
A few issues have popped up where the provided image doesn't have the required systemd package for health checking operations (like https://github.com/kubernetes/node-problem-detector/issues/584#issuecomment-885832078).

This installs systemd in the container to help alleviate these issues.