### PR TITLE
Build multi-arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE
-FROM ${BASEIMAGE}
+# The debian-base:v1.0.0 image built from kubernetes repository is based on
+# Debian Stretch. It includes systemd 232 with support for both +XZ and +LZ4
+# compression. +LZ4 is needed on some os distros such as COS.
+FROM k8s.gcr.io/debian-base-${TARGETARCH}:v2.0.0
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG LOGCOUNTER
 
 MAINTAINER Random Liu <lantaol@google.com>
 
@@ -22,10 +28,8 @@ RUN clean-install util-linux libsystemd0 bash
 # Avoid symlink of /etc/localtime.
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true
 
-COPY ./bin/node-problem-detector /node-problem-detector
-
-ARG LOGCOUNTER
-COPY ./bin/health-checker ${LOGCOUNTER} /home/kubernetes/bin/
+COPY ./output/${TARGETOS}_${TARGETARCH}/bin/node-problem-detector /node-problem-detector
+COPY ./output/${TARGETOS}_${TARGETARCH}/bin/health-checker ${LOGCOUNTER} /home/kubernetes/bin/
 
 COPY config /config
 ENTRYPOINT ["/node-problem-detector", "--config.system-log-monitor=/config/kernel-monitor.json"]


### PR DESCRIPTION
Fixes #586, Replace #588.

While trying the ARM container image from #588, I noticed that the executable inside was in the wrong architecture and creating an "exec format error".

Changes:
* Use `TARGETARCH` variable to pick the right base image in Dockerfile
* Added `build-container-amd64` and `build-container-arm64` target to Makefile
* Replace push-container target to use buildx build that push the multi-platform image to the registry