### PR TITLE
Allow skipping condition during customplugin initialization

### DIFF
--- a/docs/custom_plugin_monitor.md
+++ b/docs/custom_plugin_monitor.md
@@ -7,3 +7,4 @@
 * `max_output_length`: The maximum standard output size from custom plugins that NPD will be cut and use for condition status message.
 * `concurrency`: The plugin worker number, i.e., how many custom plugins will be invoked concurrently.
 * `enable_message_change_based_condition_update`: Flag controls whether message change should result in a condition update.
+* `skip_initial_status`: Flag controls whether condition will be emitted during plugin initialization.

--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -122,7 +122,9 @@ func (c *customPluginMonitor) Stop() {
 
 // monitorLoop is the main loop of customPluginMonitor.
 func (c *customPluginMonitor) monitorLoop() {
-	c.initializeStatus()
+	if !*c.config.PluginGlobalConfig.SkipInitialStatus {
+		c.initializeStatus()
+	}
 
 	resultChan := c.plugin.GetResultChan()
 

--- a/pkg/custompluginmonitor/types/config.go
+++ b/pkg/custompluginmonitor/types/config.go
@@ -33,6 +33,7 @@ var (
 	defaultConcurrency                       = 3
 	defaultMessageChangeBasedConditionUpdate = false
 	defaultEnableMetricsReporting            = true
+	defaultSkipInitialStatus                 = false
 
 	customPluginName = "custom"
 )
@@ -52,6 +53,8 @@ type pluginGlobalConfig struct {
 	Concurrency *int `json:"concurrency,omitempty"`
 	// EnableMessageChangeBasedConditionUpdate indicates whether NPD should enable message change based condition update.
 	EnableMessageChangeBasedConditionUpdate *bool `json:"enable_message_change_based_condition_update,omitempty"`
+	// SkipInitialStatus prevents the first status update with default conditions
+	SkipInitialStatus *bool `json:"skip_initial_status,omitempty"`
 }
 
 // Custom plugin config is the configuration of custom plugin monitor.
@@ -103,6 +106,10 @@ func (cpc *CustomPluginConfig) ApplyConfiguration() error {
 	}
 	if cpc.PluginGlobalConfig.EnableMessageChangeBasedConditionUpdate == nil {
 		cpc.PluginGlobalConfig.EnableMessageChangeBasedConditionUpdate = &defaultMessageChangeBasedConditionUpdate
+	}
+
+	if cpc.PluginGlobalConfig.SkipInitialStatus == nil {
+		cpc.PluginGlobalConfig.SkipInitialStatus = &defaultSkipInitialStatus
 	}
 
 	for _, rule := range cpc.Rules {

--- a/pkg/custompluginmonitor/types/config_test.go
+++ b/pkg/custompluginmonitor/types/config_test.go
@@ -33,6 +33,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 	concurrency := 2
 	messageChangeBasedConditionUpdate := true
 	disableMetricsReporting := false
+	disableInitialStatusUpdate := true
 
 	ruleTimeout := 1 * time.Second
 	ruleTimeoutString := ruleTimeout.String()
@@ -62,6 +63,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 					MaxOutputLength:                         &defaultMaxOutputLength,
 					Concurrency:                             &defaultConcurrency,
 					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &defaultSkipInitialStatus,
 				},
 				EnableMetricsReporting: &defaultEnableMetricsReporting,
 				Rules: []*CustomRule{
@@ -91,6 +93,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 					MaxOutputLength:                         &defaultMaxOutputLength,
 					Concurrency:                             &defaultConcurrency,
 					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &defaultSkipInitialStatus,
 				},
 				EnableMetricsReporting: &defaultEnableMetricsReporting,
 			},
@@ -110,6 +113,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 					MaxOutputLength:                         &defaultMaxOutputLength,
 					Concurrency:                             &defaultConcurrency,
 					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &defaultSkipInitialStatus,
 				},
 				EnableMetricsReporting: &defaultEnableMetricsReporting,
 			},
@@ -129,6 +133,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 					MaxOutputLength:                         &maxOutputLength,
 					Concurrency:                             &defaultConcurrency,
 					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &defaultSkipInitialStatus,
 				},
 				EnableMetricsReporting: &defaultEnableMetricsReporting,
 			},
@@ -148,6 +153,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 					MaxOutputLength:                         &defaultMaxOutputLength,
 					Concurrency:                             &concurrency,
 					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &defaultSkipInitialStatus,
 				},
 				EnableMetricsReporting: &defaultEnableMetricsReporting,
 			},
@@ -167,6 +173,7 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 					MaxOutputLength:                         &defaultMaxOutputLength,
 					Concurrency:                             &defaultConcurrency,
 					EnableMessageChangeBasedConditionUpdate: &messageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &defaultSkipInitialStatus,
 				},
 				EnableMetricsReporting: &defaultEnableMetricsReporting,
 			},
@@ -184,8 +191,28 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 					MaxOutputLength:                         &defaultMaxOutputLength,
 					Concurrency:                             &defaultConcurrency,
 					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &defaultSkipInitialStatus,
 				},
 				EnableMetricsReporting: &disableMetricsReporting,
+			},
+		},
+		"disable status update during initialization": {
+			Orig: CustomPluginConfig{PluginGlobalConfig: pluginGlobalConfig{
+				SkipInitialStatus: &disableInitialStatusUpdate,
+			},
+			},
+			Wanted: CustomPluginConfig{
+				PluginGlobalConfig: pluginGlobalConfig{
+					InvokeIntervalString:                    &defaultInvokeIntervalString,
+					InvokeInterval:                          &defaultInvokeInterval,
+					TimeoutString:                           &defaultGlobalTimeoutString,
+					Timeout:                                 &defaultGlobalTimeout,
+					MaxOutputLength:                         &defaultMaxOutputLength,
+					Concurrency:                             &defaultConcurrency,
+					EnableMessageChangeBasedConditionUpdate: &defaultMessageChangeBasedConditionUpdate,
+					SkipInitialStatus:                       &disableInitialStatusUpdate,
+				},
+				EnableMetricsReporting: &defaultEnableMetricsReporting,
 			},
 		},
 	}


### PR DESCRIPTION
Implements Option A from #645 

Allows user to specify `skip_initial_status` in plugin configuration.