### PR TITLE
FIx deprecated "MAINTAINER" in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 ARG BASEIMAGE
 FROM ${BASEIMAGE}
 
-MAINTAINER Random Liu <lantaol@google.com>
+LABEL maintainer="Random Liu <lantaol@google.com>"
 
 RUN clean-install util-linux libsystemd0 bash
 

--- a/pkg/util/nethealth/Dockerfile
+++ b/pkg/util/nethealth/Dockerfile
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 FROM busybox
-MAINTAINER Girish Kalele <gkalele@google.com>
+LABEL maintainer="Girish Kalele <gkalele@google.com>"
 COPY nethealth /usr/bin/
 ENTRYPOINT ["/usr/bin/nethealth"]

--- a/test/kernel_log_generator/Dockerfile
+++ b/test/kernel_log_generator/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM bashell/alpine-bash
-MAINTAINER Random Liu <lantaol@google.com>
+LABEL maintainer="Random Liu <lantaol@google.com>"
 
 # Use oom kill problem as default
 ENV PROBLEM /problems/oom_kill


### PR DESCRIPTION
"MAINTAINER" in Dockerfile is deprecated , refer to the https://docs.docker.com/engine/reference/builder/#maintainer-deprecated.

Change it to label.

Signed-off-by: Kay Yan <kay.yan@daocloud.io>