### PR TITLE
remove installing ginkgo using "go get" 

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -66,9 +66,6 @@ function get-version() {
 function install-lib() {
   apt-get update
   apt-get install -y libsystemd-dev gcc-aarch64-linux-gnu
-  # Turn off go modules here, because we are not trying to install
-  # ginkgo library/module. We are trying to install the ginkgo executable.
-  GO111MODULE=off go get -v github.com/onsi/ginkgo/ginkgo
 }
 
 function write-env-file() {


### PR DESCRIPTION
Remove install ginkgo using go get as the current supported version is 2.0 and 2.0 still has some conflicting changes. We can rely on the ginkgo binary compiled in kubernetes repo from the current version.

Fixes: https://github.com/kubernetes/kubernetes/issues/108856