### PR TITLE
Add ExcludeInterfaceRegexp to Net Dev monitor

### DIFF
--- a/config/net-cgroup-system-stats-monitor.json
+++ b/config/net-cgroup-system-stats-monitor.json
@@ -1,5 +1,6 @@
 {
   "net": {
+    "excludeInterfaceRegexp": "^(cali|tunl|veth)",
     "metricsConfigs": {
       "net/rx_bytes": {
         "displayName": "net/rx_bytes"

--- a/pkg/systemstatsmonitor/README.md
+++ b/pkg/systemstatsmonitor/README.md
@@ -118,6 +118,8 @@ Below metrics are collected from `net` component:
 
 All of the above have `interface_name` label for the net interface.
 
+Interfaces can be skipped if they don't add any value. See field `ExcludeInterfaceRegexp`.
+
 ## Windows Support
 
 NPD has preliminary support for system stats monitor. The following modules are supported:

--- a/pkg/systemstatsmonitor/net_collector_test.go
+++ b/pkg/systemstatsmonitor/net_collector_test.go
@@ -1,0 +1,190 @@
+package systemstatsmonitor
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"testing"
+
+	ssmtypes "k8s.io/node-problem-detector/pkg/systemstatsmonitor/types"
+	"k8s.io/node-problem-detector/pkg/util/metrics"
+)
+
+var defaultMetricsConfig = map[string]ssmtypes.MetricConfig{
+	string(metrics.NetDevRxBytes):      ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxBytes)},
+	string(metrics.NetDevRxPackets):    ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxPackets)},
+	string(metrics.NetDevRxErrors):     ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxErrors)},
+	string(metrics.NetDevRxDropped):    ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxDropped)},
+	string(metrics.NetDevRxFifo):       ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxFifo)},
+	string(metrics.NetDevRxFrame):      ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxFrame)},
+	string(metrics.NetDevRxCompressed): ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxCompressed)},
+	string(metrics.NetDevRxMulticast):  ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevRxMulticast)},
+	string(metrics.NetDevTxBytes):      ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxBytes)},
+	string(metrics.NetDevTxPackets):    ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxPackets)},
+	string(metrics.NetDevTxErrors):     ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxErrors)},
+	string(metrics.NetDevTxDropped):    ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxDropped)},
+	string(metrics.NetDevTxFifo):       ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxFifo)},
+	string(metrics.NetDevTxCollisions): ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxCollisions)},
+	string(metrics.NetDevTxCarrier):    ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxCarrier)},
+	string(metrics.NetDevTxCompressed): ssmtypes.MetricConfig{DisplayName: string(metrics.NetDevTxCompressed)},
+}
+
+// To get a similar output, run `cat /proc/net/dev` on a Linux machine
+// docker:	1500	100		8		7		0		0		0		0		9000	450		565		200		20		30		0		0
+const fakeNetProcContent = `Inter-|   Receive                                                |  Transmit
+face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+eth0:		5000	100		0		0		0 		0 		0 		0		2500	30		0		0		0		0		0		0  
+docker0: 	1000	90		8		7		0 		0 		0 		0		0		0		0		0		0		0		0		0
+docker1: 	500		10		0		0		0 		0		0		0		3000	150		15		0		20		30		0		0
+docker2:	0		0		0		0		0		0		0		0		6000	300		550		200		0		0		0		0
+`
+
+// newFakeInt64Metric is a wrapper around metrics.NewFakeInt64Metric
+func newFakeInt64Metric(metricID metrics.MetricID, viewName string, description string, unit string, aggregation metrics.Aggregation, tagNames []string) (metrics.Int64MetricInterface, error) {
+	return metrics.NewFakeInt64Metric(viewName, aggregation, tagNames), nil
+}
+
+// testCollectAux is a test auxiliary function used for testing netCollector.Collect
+func testCollectAux(t *testing.T, name string, excludeInterfaceRegexp ssmtypes.NetStatsInterfaceRegexp, validate func(*testing.T, *netCollector)) {
+	// mkdir /tmp/proc-X
+	procDir, err := ioutil.TempDir(os.TempDir(), "proc-")
+	if err != nil {
+		t.Fatalf("Failed to create temp proc directory: %v", err)
+	}
+	// rm -r /tmp/proc-X
+	defer os.RemoveAll(procDir)
+	// mkdir -C /tmp/proc-X/net
+	procNetDir := path.Join(procDir, "net")
+	if err := os.Mkdir(procNetDir, 0777); err != nil {
+		t.Fatalf("Failed to create directory %q: %v", procNetDir, err)
+	}
+
+	// touch /tmp/proc-X/net/dev
+	filename := path.Join(procNetDir, "dev")
+	f, err := os.Create(filename)
+	if err != nil {
+		t.Fatalf("Failed to create file %q: %v", filename, err)
+	}
+	// echo $FILE_CONTENT > /tmp/proc-X/net/dev
+	if _, err = f.WriteString(fakeNetProcContent); err != nil {
+		t.Fatalf("Failed to write to file %q: %v", filename, err)
+	}
+	if err = f.Close(); err != nil {
+		t.Fatalf("Failed to close file %q: %v", filename, err)
+	}
+
+	// Build the netCollector
+	config := &ssmtypes.NetStatsConfig{
+		ExcludeInterfaceRegexp: excludeInterfaceRegexp,
+		MetricsConfigs:         defaultMetricsConfig,
+	}
+	netCollector := &netCollector{
+		config:   config,
+		procPath: procDir,
+		recorder: newIfaceStatRecorder(newFakeInt64Metric),
+	}
+	netCollector.initOrDie()
+	netCollector.collect()
+	validate(t, netCollector)
+}
+
+func TestCollect(t *testing.T) {
+	tcs := []struct {
+		Name                   string
+		ExcludeInterfaceRegexp ssmtypes.NetStatsInterfaceRegexp
+		Validate               func(t *testing.T, nc *netCollector)
+	}{
+		{
+			Name:                   "NoFilterMatch",
+			ExcludeInterfaceRegexp: ssmtypes.NetStatsInterfaceRegexp{R: regexp.MustCompile(`^fake$`)},
+			Validate: func(t *testing.T, nc *netCollector) {
+				// We just validate two metrics, no need to check all of them
+				expectedValues := map[metrics.MetricID]map[string]int64{
+					metrics.NetDevRxBytes: map[string]int64{
+						"eth0":    5000,
+						"docker0": 1000,
+						"docker1": 500,
+						"docker2": 0,
+					},
+					metrics.NetDevTxBytes: map[string]int64{
+						"eth0":    2500,
+						"docker0": 0,
+						"docker1": 3000,
+						"docker2": 6000,
+					},
+				}
+				for metricID, interfaceValues := range expectedValues {
+					collector, ok := nc.recorder.collectors[metricID]
+					if !ok {
+						t.Errorf("Failed to get collector of metric %s", metricID)
+						continue
+					}
+					fakeInt64Metric, ok := collector.metric.(*metrics.FakeInt64Metric)
+					if !ok {
+						t.Fatalf("Failed to convert metric %s to fakeMetric", string(metricID))
+					}
+					for _, repr := range fakeInt64Metric.ListMetrics() {
+						interfaceName, ok := repr.Labels[interfaceNameLabel]
+						if !ok {
+							t.Fatalf("Failed to get label %q for ", interfaceNameLabel)
+						}
+						expectedValue, ok := interfaceValues[interfaceName]
+						if !ok {
+							t.Fatalf("Failed to get metric value for interface %q", interfaceName)
+						}
+						if repr.Value != expectedValue {
+							t.Errorf("Mismatch in metric %q for interface %q: expected %d, got %d", metricID, interfaceName, expectedValue, repr.Value)
+						}
+					}
+				}
+			},
+		},
+		{
+			Name:                   "FilterMatch",
+			ExcludeInterfaceRegexp: ssmtypes.NetStatsInterfaceRegexp{R: regexp.MustCompile(`docker\d+`)},
+			Validate: func(t *testing.T, nc *netCollector) {
+				// We just validate two metrics, no need to check all of them
+				expectedValues := map[metrics.MetricID]map[string]int64{
+					metrics.NetDevRxBytes: map[string]int64{
+						"eth0": 5000,
+					},
+					metrics.NetDevTxBytes: map[string]int64{
+						"eth0": 2500,
+					},
+				}
+				for metricID, interfaceValues := range expectedValues {
+					collector, ok := nc.recorder.collectors[metricID]
+					if !ok {
+						t.Errorf("Failed to get collector of metric %s", metricID)
+						continue
+					}
+					fakeInt64Metric, ok := collector.metric.(*metrics.FakeInt64Metric)
+					if !ok {
+						t.Fatalf("Failed to convert metric %s to fakeMetric", string(metricID))
+					}
+					for _, repr := range fakeInt64Metric.ListMetrics() {
+						interfaceName, ok := repr.Labels[interfaceNameLabel]
+						if !ok {
+							t.Fatalf("Failed to get label %q for ", interfaceNameLabel)
+						}
+						expectedValue, ok := interfaceValues[interfaceName]
+						if !ok {
+							t.Fatalf("Failed to get metric value for interface %q", interfaceName)
+						}
+						if repr.Value != expectedValue {
+							t.Errorf("Mismatch in metric %q for interface %q: expected %d, got %d", metricID, interfaceName, expectedValue, repr.Value)
+						}
+					}
+				}
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			testCollectAux(t, tc.Name, tc.ExcludeInterfaceRegexp, tc.Validate)
+		})
+	}
+}

--- a/pkg/systemstatsmonitor/types/config.go
+++ b/pkg/systemstatsmonitor/types/config.go
@@ -19,6 +19,7 @@ package types
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 )
 
@@ -58,8 +59,35 @@ type OSFeatureStatsConfig struct {
 	KnownModulesConfigPath string                  `json:"knownModulesConfigPath"`
 }
 
+// In order to marshal/unmarshal regexp, we need to implement
+// MarshalText/UnmarshalText methods in a wrapper struct
+type NetStatsInterfaceRegexp struct {
+	R *regexp.Regexp
+}
+
+func (r *NetStatsInterfaceRegexp) UnmarshalText(data []byte) error {
+	// We don't build Regexp if data is empty
+	if len(data) == 0 {
+		return nil
+	}
+	regex, err := regexp.Compile(string(data))
+	if err != nil {
+		return err
+	}
+	r.R = regex
+	return nil
+}
+
+func (r NetStatsInterfaceRegexp) MarshalText() ([]byte, error) {
+	if r.R == nil {
+		return nil, nil
+	}
+	return []byte(r.R.String()), nil
+}
+
 type NetStatsConfig struct {
-	MetricsConfigs map[string]MetricConfig `json:"metricsConfigs"`
+	MetricsConfigs         map[string]MetricConfig `json:"metricsConfigs"`
+	ExcludeInterfaceRegexp NetStatsInterfaceRegexp `json:"excludeInterfaceRegexp"`
 }
 
 type SystemStatsConfig struct {


### PR DESCRIPTION
## What does this PR do?
As a solution for #659, this PR adds field `ExcludeInterfaceRegexp` to network device monitor. This field is used to stop tracking metrics for certain network interfaces. 

This change also edits config `net-cgroup-system-stats-monitor.json` to exclude Calico interfaces (according to [this doc](https://projectcalico.docs.tigera.io/getting-started/kubernetes/quickstart?gclid=CjwKCAjw46CVBhB1EiwAgy6M4iLRp-n6jcNQycdqjpEOZapTChXAi3en-x9XdIBgQzT2wa2gnBqDpRoCUGwQAvD_BwE), `cali` and `tunl` interfaces) and `veth`, which are interfaces created dynamically and only add noise to the metrics.

Additionally, I refactored the code in order to make it more testable and added some unit tests.

## How to test this change?
1. Create a Kubernetes cluster that uses Calico (I personally used GKE and followed instructions [here](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy)). Ensure the cluster uses the new NPD version and config (in my case, I manually copied the binaries and config to the node).
2. Run some workload, trigger new network interfaces creation, and ensure metrics are not being reported for Calico interfaces.