### PR TITLE
Add condition message to event message

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -232,6 +232,7 @@ func (c *customPluginMonitor) generateStatus(result cpmtypes.Result) *types.Stat
 						condition.Type,
 						status,
 						newReason,
+						newMessage,
 						timestamp,
 					)
 

--- a/pkg/systemlogmonitor/log_monitor.go
+++ b/pkg/systemlogmonitor/log_monitor.go
@@ -192,6 +192,7 @@ func (l *logMonitor) generateStatus(logs []*logtypes.Log, rule systemlogtypes.Ru
 						condition.Type,
 						types.True,
 						rule.Reason,
+						message,
 						timestamp,
 					))
 				}

--- a/pkg/systemlogmonitor/log_monitor_test.go
+++ b/pkg/systemlogmonitor/log_monitor_test.go
@@ -84,6 +84,7 @@ func TestGenerateStatusForConditions(t *testing.T) {
 					testConditionA,
 					types.True,
 					"test reason",
+					"test message 1\ntest message 2",
 					time.Unix(1000, 1000),
 				)},
 				Conditions: []types.Condition{

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -23,12 +23,12 @@ import (
 )
 
 // GenerateConditionChangeEvent generates an event for condition change.
-func GenerateConditionChangeEvent(t string, status types.ConditionStatus, reason string, timestamp time.Time) types.Event {
+func GenerateConditionChangeEvent(t string, status types.ConditionStatus, reason, message string, timestamp time.Time) types.Event {
 	return types.Event{
 		Severity:  types.Info,
 		Timestamp: timestamp,
 		Reason:    reason,
-		Message:   fmt.Sprintf("Node condition %s is now: %s, reason: %s", t, status, reason),
+		Message:   fmt.Sprintf("Node condition %s is now: %s, reason: %s, message: %s", t, status, reason, message),
 	}
 }
 

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -28,7 +28,7 @@ func GenerateConditionChangeEvent(t string, status types.ConditionStatus, reason
 		Severity:  types.Info,
 		Timestamp: timestamp,
 		Reason:    reason,
-		Message:   fmt.Sprintf("Node condition %s is now: %s, reason: %s, message: %s", t, status, reason, message),
+		Message:   fmt.Sprintf("Node condition %s is now: %s, reason: %s, message: %q", t, status, reason, message),
 	}
 }
 


### PR DESCRIPTION
If you're using some monitoring solution that aggregates events from your Kubernetes cluster, (e.g., Datadog,) having the underlying reason why a condition triggered could be very useful, especially if you are using custom plugin monitors.

Obviously, the fact that a `message` field contains the word "message" in it is a little awkward, but I didn't know what else to call it, besides something that seemed redundant like "condition message." I'm totally open to suggestions here, as long as the message contents get included somehow.

I could not find a documented upper bound on the size of the `message` field in `core.v1.Event`, so I didn't attempt to truncate the message here. Please let me know if I should do so anyway.