### PR TITLE
Remove unused resultChan field in CPM

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -47,7 +47,6 @@ type customPluginMonitor struct {
 	config     cpmtypes.CustomPluginConfig
 	conditions []types.Condition
 	plugin     *plugin.Plugin
-	resultChan <-chan cpmtypes.Result
 	statusChan chan *types.Status
 	tomb       *tomb.Tomb
 }


### PR DESCRIPTION
This commit removes the resultChan field in ./pkg/custompluginmonitor's
customPluginMonitor struct. This was detected by staticcheck:

    ―❤―▶ staticcheck ./pkg/custompluginmonitor/
    pkg/custompluginmonitor/custom_plugin_monitor.go:50:2: field resultChan is unused (U1000)