### PR TITLE
[release-blocker-fix] fix building multi-arch image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ $(NPD_NAME_VERSION)-%.tar.gz: $(ALL_BINARIES) test/e2e-install.sh
 build-binaries: $(ALL_BINARIES)
 
 build-container: clean Dockerfile
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 	docker buildx create --use
 	docker buildx build --platform $(DOCKER_PLATFORMS) -t $(IMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
 


### PR DESCRIPTION
There is a error in building the multi-arch and the error is below

```#0 15.05 Fetched 4126 kB in 0s (10.1 MB/s)
#0 15.19 Error while loading /usr/sbin/dpkg-split: No such file or directory
#0 15.20 Error while loading /usr/sbin/dpkg-deb: No such file or directory
#```

This requires to run qemu-static to run before building the multi-arch image