### PR TITLE
fix helm command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The easiest way to install node-problem-detector into your cluster is to use the
 
 ```
 helm repo add deliveryhero https://charts.deliveryhero.io/
-helm install deliveryhero/node-problem-detector
+helm install --generate-name deliveryhero/node-problem-detector
 ```
 
 Alternatively, to install node-problem-detector manually:


### PR DESCRIPTION
installation command written in doc https://github.com/kubernetes/node-problem-detector#installation
```
helm install deliveryhero/node-problem-detector
```
fails with the error
```
Error: INSTALLATION FAILED: must either provide a name or specify --generate-name
```
we can avoid this error by using commant
```
helm install --generate-name deliveryhero/node-problem-detector
```

This PR fix this doc.