### PR TITLE
output stdout and stderr from custom commands, allow setting timeout for critctl

### DIFF
--- a/cmd/healthchecker/options/options.go
+++ b/cmd/healthchecker/options/options.go
@@ -39,6 +39,7 @@ type HealthCheckerOptions struct {
 	EnableRepair       bool
 	CriCtlPath         string
 	CriSocketPath      string
+	CriTimeout         time.Duration
 	CoolDownTime       time.Duration
 	LoopBackTime       time.Duration
 	HealthCheckTimeout time.Duration
@@ -62,6 +63,8 @@ func (hco *HealthCheckerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The path to the crictl binary. This is used to check health of cri component.")
 	fs.StringVar(&hco.CriSocketPath, "cri-socket-path", types.DefaultCriSocketPath,
 		"The path to the cri socket. Used with crictl to specify the socket path.")
+	fs.DurationVar(&hco.CriTimeout, "cri-timeout", types.DefaultCriTimeout,
+		"The duration to wait for crictl to run.")
 	fs.DurationVar(&hco.CoolDownTime, "cooldown-time", types.DefaultCoolDownTime,
 		"The duration to wait for the service to be up before attempting repair.")
 	fs.DurationVar(&hco.LoopBackTime, "loopback-time", types.DefaultLoopBackTime,

--- a/pkg/healthchecker/health_checker.go
+++ b/pkg/healthchecker/health_checker.go
@@ -167,10 +167,11 @@ func execCommand(timeout time.Duration, command string, args ...string) (string,
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, command, args...)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		glog.Infof("command %v failed: %v, %v\n", cmd, err, out)
 		return "", err
 	}
+
 	return strings.TrimSuffix(string(out), "\n"), nil
 }

--- a/pkg/healthchecker/health_checker.go
+++ b/pkg/healthchecker/health_checker.go
@@ -150,7 +150,7 @@ func getHealthCheckFunc(hco *options.HealthCheckerOptions) func() (bool, error) 
 		}
 	case types.CRIComponent:
 		return func() (bool, error) {
-			if _, err := execCommand(hco.HealthCheckTimeout, hco.CriCtlPath, "--runtime-endpoint="+hco.CriSocketPath, "pods", "--latest"); err != nil {
+			if _, err := execCommand(hco.HealthCheckTimeout, hco.CriCtlPath, "--timeout="+hco.CriTimeout.String()+"--runtime-endpoint="+hco.CriSocketPath, "pods", "--latest"); err != nil {
 				return false, nil
 			}
 			return true, nil

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	DefaultLoopBackTime       = 0 * time.Minute
+	DefaultCriTimeout         = 2 * time.Second
 	DefaultCoolDownTime       = 2 * time.Minute
 	DefaultHealthCheckTimeout = 10 * time.Second
 	CmdTimeout                = 10 * time.Second


### PR DESCRIPTION
### Problems

 - We are seeing intermittent failures on our custom command for containerd, errors from `crictl` appear to be printed on stderr; since only stdout is output it's difficult to debug what the failure is.

 - `crictl` at [one point](https://github.com/kubernetes-sigs/cri-tools/commit/f9bb11cc0b3993a7078b98fa559bf93ac12155e5) updated the tools timeout from 10s to 2s; it's possible this timeout is the source of our intermittent errors


### Solution

 - output stderr as well as stdout
 - allow setting critctl timeout via npd configs