### PR TITLE
Update comment to be consistent with reality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ ENABLE_JOURNALD=0
 endif
 
 # TODO(random-liu): Support different architectures.
-# The debian-base:v1.0.0 image built from kubernetes repository is based on
-# Debian Stretch. It includes systemd 232 with support for both +XZ and +LZ4
+# The debian-base:v2.0.0 image built from kubernetes repository is based on
+# Debian Stretch. It includes systemd 241 with support for both +XZ and +LZ4
 # compression. +LZ4 is needed on some os distros such as COS.
 BASEIMAGE:=k8s.gcr.io/debian-base:v2.0.0
 


### PR DESCRIPTION
It looks like the base image was bumped but the comment wasn't. Update it.

This is how I determined the version of systemd in the new version of the base image:

```
❯ podman run --rm -it --entrypoint sh k8s.gcr.io/debian-base:v2.0.0
# systemctl --version
sh: 1: systemctl: not found
# apt info systemd
Package: systemd
State: not a real package (virtual)
N: Can't select candidate version from package systemd as it has no candidate
N: Can't select versions from package 'systemd' as it is purely virtual
N: No packages found
# apt update
Get:1 http://security.debian.org/debian-security buster/updates InRelease [34.8 kB]
Get:2 http://deb.debian.org/debian buster InRelease [122 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [56.6 kB]
Get:4 http://deb.debian.org/debian buster/main amd64 Packages [7909 kB]
Reading package lists... Done
E: Release file for http://security.debian.org/debian-security/dists/buster/updates/InRelease is not valid yet (invalid for another 2d 7h 17min 43s). Updates for this repository will not be applied.
E: Release file for http://deb.debian.org/debian/dists/buster-updates/InRelease is not valid yet (invalid for another 2d 18h 22min 5s). Updates for this repository will not be applied.
# apt install libsystemd-dev
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following additional packages will be installed:
  libsystemd0
The following NEW packages will be installed:
  libsystemd-dev
The following packages will be upgraded:
  libsystemd0
1 upgraded, 1 newly installed, 0 to remove and 23 not upgraded.
Need to get 654 kB of archives.
After this operation, 882 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://deb.debian.org/debian buster/main amd64 libsystemd0 amd64 241-7~deb10u8 [331 kB]
Get:2 http://deb.debian.org/debian buster/main amd64 libsystemd-dev amd64 241-7~deb10u8 [322 kB]
Fetched 654 kB in 1s (1224 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 3890 files and directories currently installed.)
Preparing to unpack .../libsystemd0_241-7~deb10u8_amd64.deb ...
Unpacking libsystemd0:amd64 (241-7~deb10u8) over (241-7~deb10u1) ...
Setting up libsystemd0:amd64 (241-7~deb10u8) ...
Selecting previously unselected package libsystemd-dev:amd64.
(Reading database ... 3890 files and directories currently installed.)
Preparing to unpack .../libsystemd-dev_241-7~deb10u8_amd64.deb ...
Unpacking libsystemd-dev:amd64 (241-7~deb10u8) ...
Setting up libsystemd-dev:amd64 (241-7~deb10u8) ...
Processing triggers for libc-bin (2.28-10) ...
```

So `Setting up libsystemd-dev:amd64 (241-7~deb10u8) ...` makes me believe that 241 is the version used.