### PR TITLE
Kmsg priority

### DIFF
--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
@@ -136,7 +136,7 @@ func (k *kernelLogWatcher) watchLoop() {
 			// higher priority
 			// than the one defined
 			if k.priority != nil && uint64(msg.Priority) > *k.priority {
-				glog.V(5).Infof("Throwing away msg %q due to tis priority: %v > %v", msg.Message, msg.Priority, k.priority)
+				glog.V(5).Infof("Throwing away msg %q due to tis priority: %v > %v", msg.Message, msg.Priority, *k.priority)
 				continue
 			}
 

--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
@@ -133,10 +133,12 @@ func (k *kernelLogWatcher) watchLoop() {
 			}
 
 			// In case priority has been set, discard message which have a
-			// higher priority
-			// than the one defined
+			// higher priority than the one defined
 			if k.priority != nil && uint64(msg.Priority) > *k.priority {
-				glog.V(5).Infof("Throwing away msg %q due to tis priority: %v > %v", msg.Message, msg.Priority, *k.priority)
+				glog.V(5).Infof(
+					"Throwing away msg %q due to its priority: Message Priority: %v > Threshold: %v",
+					msg.Message, msg.Priority, *k.priority,
+				)
 				continue
 			}
 

--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux_test.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux_test.go
@@ -149,6 +149,7 @@ func TestWatch(t *testing.T) {
 		},
 		{
 			// The start point is at the head of the log file.
+			// Only logs with priority equal or less than 3 will not be filtered
 			uptime:   0,
 			lookback: "0",
 			delay:    "0",
@@ -157,11 +158,16 @@ func TestWatch(t *testing.T) {
 				{Message: "1", Timestamp: now.Add(0 * time.Second), Priority: 9},
 				{Message: "2", Timestamp: now.Add(1 * time.Second), Priority: 2},
 				{Message: "3", Timestamp: now.Add(2 * time.Second), Priority: 5},
+				{Message: "4", Timestamp: now.Add(3 * time.Second), Priority: 3},
 			}},
 			logs: []logtypes.Log{
 				{
 					Timestamp: now.Add(time.Second),
 					Message:   "2",
+				},
+				{
+					Timestamp: now.Add(3 * time.Second),
+					Message:   "4",
 				},
 			},
 		},


### PR DESCRIPTION
# Summary
The following PR adds a pluginConfig option to the kmsg systemlogmonitor to filter messages via its priority. Issue #699 was opened to request permissions to add this. 

By default if no parameter is defined in the pluginConfig, the Kmsg logmonitor won't filter any message. That's the behaviour of the plugin before adding this change, so for this reason the change is backward compatible. 

The plugin will filter kernel messages that have a priority higher than the one defined if the pluginConfig with the key `priority` is defined