### PR TITLE
add NIC link state metric

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -64,6 +64,11 @@
 			"pattern": "CE memory read error .*"
 		},
 		{
+			"type": "temporary",
+			"reason": "NICFlapping",
+			"pattern": "NIC Link is Down"
+		},
+		{
 			"type": "permanent",
 			"condition": "KernelDeadlock",
 			"reason": "DockerHung",

--- a/deployment/node-problem-detector-config.yaml
+++ b/deployment/node-problem-detector-config.yaml
@@ -51,6 +51,11 @@ data:
     			"pattern": "CE memory read error .*"
             },
             {
+                "type": "temporary",
+                "reason": "NICFlapping",
+                "pattern": "NIC Link is Down"
+            },
+            {
                 "type": "permanent",
                 "condition": "KernelDeadlock",
                 "reason": "DockerHung",


### PR DESCRIPTION
dmesg log:
```
[Wed May 26 15:21:05 2021] ixgbe 0000:af:00.1 enp175s0f1: NIC Link is Down
[Wed May 26 15:21:05 2021] ixgbe 0000:af:00.1 enp175s0f1: speed changed to 0 for port enp175s0f1
[Wed May 26 15:21:06 2021] ixgbe 0000:af:00.1 enp175s0f1: NIC Link is Up 10 Gbps, Flow Control: RX/TX
```