### PR TITLE
add initial-invoke-internal to speed up checks after booting a host

### DIFF
--- a/docs/custom_plugin_monitor.md
+++ b/docs/custom_plugin_monitor.md
@@ -3,6 +3,7 @@
 ## Configuration
 ### Plugin Config
 * `invoke_interval`: Interval at which custom plugins will be invoked.
+* `initial_invoke_interval`: Interval at which custom plugins will be invoked for the first 5 checks after booting.
 * `timeout`: Time after which custom plugins invokation will be terminated and considered timeout.
 * `max_output_length`: The maximum standard output size from custom plugins that NPD will be cut and use for condition status message.
 * `concurrency`: The plugin worker number, i.e., how many custom plugins will be invoked concurrently.

--- a/pkg/custompluginmonitor/types/config.go
+++ b/pkg/custompluginmonitor/types/config.go
@@ -41,10 +41,14 @@ var (
 type pluginGlobalConfig struct {
 	// InvokeIntervalString is the interval string at which plugins will be invoked.
 	InvokeIntervalString *string `json:"invoke_interval,omitempty"`
+	// InitialInvokeIntervalString is the interval string at which plugins will be invoked for the first 5 checks after booting.
+	InitialInvokeIntervalString *string `json:"initial_invoke_interval,omitempty"`
 	// TimeoutString is the global plugin execution timeout string.
 	TimeoutString *string `json:"timeout,omitempty"`
 	// InvokeInterval is the interval at which plugins will be invoked.
 	InvokeInterval *time.Duration `json:"-"`
+	// InitialInvokeInterval is the interval at which plugins will be invoked for the first 5 checks after booting.
+	InitialInvokeInterval *time.Duration `json:"-"`
 	// Timeout is the global plugin execution timeout.
 	Timeout *time.Duration `json:"-"`
 	// MaxOutputLength is the maximum plugin output message length.
@@ -97,6 +101,16 @@ func (cpc *CustomPluginConfig) ApplyConfiguration() error {
 	}
 
 	cpc.PluginGlobalConfig.InvokeInterval = &invokeInterval
+
+	// set optional InitialInvokeIntervalString if given
+	if cpc.PluginGlobalConfig.InitialInvokeIntervalString != nil {
+		initialInvokeInterval, err := time.ParseDuration(*cpc.PluginGlobalConfig.InitialInvokeIntervalString)
+		if err != nil {
+			return fmt.Errorf("error in parsing initial invoke interval %q: %v", *cpc.PluginGlobalConfig.InitialInvokeIntervalString, err)
+		}
+
+		cpc.PluginGlobalConfig.InitialInvokeInterval = &initialInvokeInterval
+	}
 
 	if cpc.PluginGlobalConfig.MaxOutputLength == nil {
 		cpc.PluginGlobalConfig.MaxOutputLength = &defaultMaxOutputLength


### PR DESCRIPTION
fixes https://github.com/kubernetes/node-problem-detector/issues/313