### PR TITLE
log failed results at a higher verbosity level

### DIFF
--- a/pkg/custompluginmonitor/plugin/plugin.go
+++ b/pkg/custompluginmonitor/plugin/plugin.go
@@ -103,12 +103,12 @@ func (p *Plugin) runRules() {
 
 			start := time.Now()
 			exitStatus, message := p.run(*rule)
-			level := 3
+			level := glog.Level(3)
 			if exitStatus != 0 {
-				level = 2
+				level = glog.Level(2)
 			}
 
-			glog.V(glog.Level(level)).Infof("Rule: %+v. Start time: %v. End time: %v. Duration: %v", rule, start, time.Now(), time.Since(start))
+			glog.V(level).Infof("Rule: %+v. Start time: %v. End time: %v. Duration: %v", rule, start, time.Now(), time.Since(start))
 
 			result := cpmtypes.Result{
 				Rule:       rule,
@@ -119,7 +119,7 @@ func (p *Plugin) runRules() {
 			p.resultChan <- result
 
 			// Let the result be logged at a higher verbosity level. If there is a change in status it is logged later.
-			glog.V(3).Infof("Add check result %+v for rule %+v", result, rule)
+			glog.V(level).Infof("Add check result %+v for rule %+v", result, rule)
 		}(rule)
 	}
 


### PR DESCRIPTION
follow-up to https://github.com/kubernetes/node-problem-detector/pull/668
which showed the rule but not the result ... let's have them at the same level

/cc @Random-Liu 