### PR TITLE
remove "Start watching journald" to avoid plugin log spam

### DIFF
--- a/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
@@ -1,3 +1,4 @@
+//go:build journald
 // +build journald
 
 /*
@@ -77,7 +78,6 @@ func (j *journaldWatcher) Watch() (<-chan *logtypes.Log, error) {
 		return nil, err
 	}
 	j.journal = journal
-	glog.Info("Start watching journald")
 	go j.watchLoop()
 	return j.logCh, nil
 }


### PR DESCRIPTION
atm we see lots of this, would be nice to not have it 🤷 
```
Start logs from plugin  ...
I1019 21:25:24.665373     571 log_watcher.go:80] Start watching journald","pattern":"plugin-logs"}
End logs from plugin ...
```
(if it's not there then the output is empty and the "logs from plugin" goes away)

I know this can be avoided by setting log-level to <=2 but it's pretty verbose even for info level "hey this plugin did nothing" 🤷 