### PR TITLE
health-checker cri: fix invalid command

### DIFF
--- a/pkg/healthchecker/health_checker.go
+++ b/pkg/healthchecker/health_checker.go
@@ -150,7 +150,15 @@ func getHealthCheckFunc(hco *options.HealthCheckerOptions) func() (bool, error) 
 		}
 	case types.CRIComponent:
 		return func() (bool, error) {
-			if _, err := execCommand(hco.HealthCheckTimeout, hco.CriCtlPath, "--timeout="+hco.CriTimeout.String()+"--runtime-endpoint="+hco.CriSocketPath, "pods", "--latest"); err != nil {
+			_, err := execCommand(
+				hco.HealthCheckTimeout,
+				hco.CriCtlPath,
+				"--timeout="+hco.CriTimeout.String(),
+				"--runtime-endpoint="+hco.CriSocketPath,
+				"pods",
+				"--latest",
+			)
+			if err != nil {
 				return false, nil
 			}
 			return true, nil


### PR DESCRIPTION
atm produces this, note the missing space between the 2 options
```
--timeout=2s--runtime-endpoint=unix:///var/run/containerd/containerd.sock path
```

broke [here](https://github.com/kubernetes/node-problem-detector/pull/702)
@karlhungus 
@vteratipally