### PR TITLE
Add arm build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@
 all: build
 
 # PLATFORMS is the set of OS_ARCH that NPD can build against.
-LINUX_PLATFORMS=linux_amd64 linux_arm64
-DOCKER_PLATFORMS=linux/amd64,linux/arm64
+LINUX_PLATFORMS=linux_amd64 linux_arm64 linux_arm
+DOCKER_PLATFORMS=linux/amd64,linux/arm64,linux/arm
 PLATFORMS=$(LINUX_PLATFORMS) windows_amd64
 
 # VERSION is the version of the binary.
@@ -182,6 +182,24 @@ output/linux_arm64/test/bin/%: $(PKG_SOURCES)
 		-tags "$(LINUX_BUILD_TAGS)" \
 		./test/e2e/$(subst -,,$*)
 
+output/linux_arm/bin/%: $(PKG_SOURCES)
+	GOOS=linux GOARCH=arm CGO_ENABLED=$(CGO_ENABLED) GO111MODULE=on \
+	  CC=arm-linux-gnu-gcc go build \
+		-mod vendor \
+		-o $@ \
+		-ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
+		-tags "$(LINUX_BUILD_TAGS)" \
+		./cmd/$(subst -,,$*)
+	touch $@
+
+output/linux_arm/test/bin/%: $(PKG_SOURCES)
+	GOOS=linux GOARCH=arm CGO_ENABLED=$(CGO_ENABLED) GO111MODULE=on \
+	  CC=arm-linux-gnu-gcc go build \
+		-mod vendor \
+		-o $@ \
+		-tags "$(LINUX_BUILD_TAGS)" \
+		./test/e2e/$(subst -,,$*)
+		
 # In the future these targets should be deprecated.
 ./bin/log-counter: $(PKG_SOURCES)
 ifeq ($(ENABLE_JOURNALD), 1)


### PR DESCRIPTION
Hi

I'd like to add arm v7 support to the problem detector builds and container image.

Could you let me know if those changes are sufficient?

I'm not particularly sure about `CC=arm-linux-gnu-gcc`, should it be `gcc-arm-linux-gnueabi`?

Thanks