### PR TITLE
update BASEIMAGE to debian-base:bullseye-v1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ FROM ${BASEIMAGE}
 
 LABEL maintainer="Random Liu <lantaol@google.com>"
 
-RUN clean-install util-linux libsystemd0 bash systemd
+RUN clean-install util-linux bash libsystemd-dev
 
 # Avoid symlink of /etc/localtime.
 RUN test -h /etc/localtime && rm -f /etc/localtime && cp /usr/share/zoneinfo/UTC /etc/localtime || true

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 # The debian-base:v2.0.0 image built from kubernetes repository is based on
 # Debian Stretch. It includes systemd 241 with support for both +XZ and +LZ4
 # compression. +LZ4 is needed on some os distros such as COS.
-BASEIMAGE:=k8s.gcr.io/debian-base:v2.0.0
+BASEIMAGE:=registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
 
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0


### PR DESCRIPTION
This is the latest Debian Bullseye image, it is the same as used in other Kubernetes projects, i.e. https://github.com/kubernetes-sigs/blob-csi-driver/pull/765/files