### PR TITLE
optionally read node and port information from env variables for kube* services

### DIFF
--- a/pkg/healthchecker/health_checker.go
+++ b/pkg/healthchecker/health_checker.go
@@ -138,9 +138,9 @@ func healthCheckEndpointOKFunc(endpoint string, timeout time.Duration) func() (b
 func getHealthCheckFunc(hco *options.HealthCheckerOptions) func() (bool, error) {
 	switch hco.Component {
 	case types.KubeletComponent:
-		return healthCheckEndpointOKFunc(types.KubeletHealthCheckEndpoint, hco.HealthCheckTimeout)
+		return healthCheckEndpointOKFunc(types.KubeletHealthCheckEndpoint(), hco.HealthCheckTimeout)
 	case types.KubeProxyComponent:
-		return healthCheckEndpointOKFunc(types.KubeProxyHealthCheckEndpoint, hco.HealthCheckTimeout)
+		return healthCheckEndpointOKFunc(types.KubeProxyHealthCheckEndpoint(), hco.HealthCheckTimeout)
 	case types.DockerComponent:
 		return func() (bool, error) {
 			if _, err := execCommand(hco.HealthCheckTimeout, getDockerPath(), "ps"); err != nil {

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -44,7 +44,7 @@ const (
 	kubeletPortKey          = "KUBELET_PORT"
 	kubeProxyPortKey        = "KUBEPROXY_PORT"
 
-	defaultHost          = "127.0.0.1"
+	defaultHostAddress   = "127.0.0.1"
 	defaultKubeletPort   = "10248"
 	defaultKubeproxyPort = "10256"
 )
@@ -61,7 +61,7 @@ func init() {
 func setKubeEndpoints() {
 	var o string
 
-	hostAddress := defaultHost
+	hostAddress := defaultHostAddress
 	kubeletPort := defaultKubeletPort
 	kubeProxyPort := defaultKubeproxyPort
 

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -40,19 +40,18 @@ const (
 	KubeProxyComponent = "kube-proxy"
 
 	LogPatternFlagSeparator = ":"
+	hostAddressKey          = "HOST_ADDRESS"
+	kubeletPortKey          = "KUBELET_PORT"
+	kubeProxyPortKey        = "KUBEPROXY_PORT"
 
-	nodeEnvKey       = "HOST_IP"
-	kubeletPortKey   = "KUBELET_PORT"
-	kubeProxyPortKey = "KUBEPROXY_PORT"
-
-	defaultHostIP        = "127.0.0.1"
+	defaultHost          = "127.0.0.1"
 	defaultKubeletPort   = "10248"
 	defaultKubeproxyPort = "10256"
 )
 
 var (
-	KubeletHealthCheckEndpoint   string
-	KubeProxyHealthCheckEndpoint string
+	kubeletHealthCheckEndpoint   string
+	kubeProxyHealthCheckEndpoint string
 )
 
 func init() {
@@ -62,13 +61,13 @@ func init() {
 func setKubeEndpoints() {
 	var o string
 
-	hostIP := defaultHostIP
+	hostAddress := defaultHost
 	kubeletPort := defaultKubeletPort
 	kubeProxyPort := defaultKubeproxyPort
 
-	o = os.Getenv(nodeEnvKey)
+	o = os.Getenv(hostAddressKey)
 	if o != "" {
-		hostIP = o
+		hostAddress = o
 	}
 	o = os.Getenv(kubeletPortKey)
 	if o != "" {
@@ -79,9 +78,16 @@ func setKubeEndpoints() {
 		kubeProxyPort = o
 	}
 
-	KubeletHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostIP, kubeletPort)
-	KubeProxyHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostIP, kubeProxyPort)
+	kubeletHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostAddress, kubeletPort)
+	kubeProxyHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostAddress, kubeProxyPort)
 
+}
+
+func KubeProxyHealthCheckEndpoint() string {
+	return kubeProxyHealthCheckEndpoint
+}
+func KubeletHealthCheckEndpoint() string {
+	return kubeletHealthCheckEndpoint
 }
 
 type HealthChecker interface {

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,11 +39,41 @@ const (
 	ContainerdService  = "containerd"
 	KubeProxyComponent = "kube-proxy"
 
+	LogPatternFlagSeparator = ":"
+
+	nodeEnvKey    = "HOST_IP"
+	kubeletPort   = "KUBELET_PORT"
+	kubeProxyPort = "KUBEPROXY_PORT"
+)
+
+var (
 	KubeletHealthCheckEndpoint   = "http://127.0.0.1:10248/healthz"
 	KubeProxyHealthCheckEndpoint = "http://127.0.0.1:10256/healthz"
-
-	LogPatternFlagSeparator = ":"
 )
+
+func init() {
+	var o string
+
+	hostIP := "127.0.0.1"
+	kubeletPort := "10248"
+	kubeProxyPort := "10256"
+
+	o = os.Getenv(nodeEnvKey)
+	if o != "" {
+		hostIP = o
+	}
+	o = os.Getenv(kubeletPort)
+	if o != "" {
+		kubeletPort = o
+	}
+	o = os.Getenv(kubeProxyPort)
+	if o != "" {
+		kubeProxyPort = o
+	}
+
+	KubeletHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostIP, kubeletPort)
+	KubeProxyHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostIP, kubeProxyPort)
+}
 
 type HealthChecker interface {
 	CheckHealth() (bool, error)

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -44,6 +44,10 @@ const (
 	nodeEnvKey       = "HOST_IP"
 	kubeletPortKey   = "KUBELET_PORT"
 	kubeProxyPortKey = "KUBEPROXY_PORT"
+
+	defaultHostIP        = "127.0.0.1"
+	defaultKubeletPort   = "10248"
+	defaultKubeproxyPort = "10256"
 )
 
 var (
@@ -58,9 +62,9 @@ func init() {
 func setKubeEndpoints() {
 	var o string
 
-	hostIP := "127.0.0.1"
-	kubeletPort := "10248"
-	kubeProxyPort := "10256"
+	hostIP := defaultHostIP
+	kubeletPort := defaultKubeletPort
+	kubeProxyPort := defaultKubeproxyPort
 
 	o = os.Getenv(nodeEnvKey)
 	if o != "" {

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -41,9 +41,9 @@ const (
 
 	LogPatternFlagSeparator = ":"
 
-	nodeEnvKey    = "HOST_IP"
-	kubeletPort   = "KUBELET_PORT"
-	kubeProxyPort = "KUBEPROXY_PORT"
+	nodeEnvKey       = "HOST_IP"
+	kubeletPortKey   = "KUBELET_PORT"
+	kubeProxyPortKey = "KUBEPROXY_PORT"
 )
 
 var (
@@ -62,11 +62,11 @@ func init() {
 	if o != "" {
 		hostIP = o
 	}
-	o = os.Getenv(kubeletPort)
+	o = os.Getenv(kubeletPortKey)
 	if o != "" {
 		kubeletPort = o
 	}
-	o = os.Getenv(kubeProxyPort)
+	o = os.Getenv(kubeProxyPortKey)
 	if o != "" {
 		kubeProxyPort = o
 	}

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -52,6 +52,10 @@ var (
 )
 
 func init() {
+	setKubeEndpoints()
+}
+
+func setKubeEndpoints() {
 	var o string
 
 	hostIP := "127.0.0.1"
@@ -73,6 +77,7 @@ func init() {
 
 	KubeletHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostIP, kubeletPort)
 	KubeProxyHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostIP, kubeProxyPort)
+
 }
 
 type HealthChecker interface {

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -47,8 +47,8 @@ const (
 )
 
 var (
-	KubeletHealthCheckEndpoint   = "http://127.0.0.1:10248/healthz"
-	KubeProxyHealthCheckEndpoint = "http://127.0.0.1:10256/healthz"
+	KubeletHealthCheckEndpoint   string
+	KubeProxyHealthCheckEndpoint string
 )
 
 func init() {

--- a/pkg/healthchecker/types/types_test.go
+++ b/pkg/healthchecker/types/types_test.go
@@ -109,31 +109,31 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 		{
 			name:                      "no overrides supplied",
 			envConfig:                 map[string]string{},
-			expectedKubeletEndpoint:   "http://127.0.0.1:10248",
-			expectedKubeProxyEndpoint: "http://127.0.0.1:10256",
+			expectedKubeletEndpoint:   "http://127.0.0.1:10248/healthz",
+			expectedKubeProxyEndpoint: "http://127.0.0.1:10256/healthz",
 		}, {
 			name: "HOST_ADDRESS override supplied",
 			envConfig: map[string]string{
 				"HOST_ADDRESS": "samplehost.testdomain.com",
 			},
-			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:10248",
-			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:10256",
+			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:10248/healthz",
+			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:10256/healthz",
 		},
 		{
 			name: "KUBELET_PORT override supplied",
 			envConfig: map[string]string{
 				"KUBELET_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "http://127.0.0.1:12345",
-			expectedKubeProxyEndpoint: "http://127.0.0.1:10256",
+			expectedKubeletEndpoint:   "http://127.0.0.1:12345/healthz",
+			expectedKubeProxyEndpoint: "http://127.0.0.1:10256/healthz",
 		},
 		{
 			name: "KUBEPROXY_PORT override supplied",
 			envConfig: map[string]string{
 				"KUBEPROXY_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "http://127.0.0.1:10248",
-			expectedKubeProxyEndpoint: "http://127.0.0.1:12345",
+			expectedKubeletEndpoint:   "http://127.0.0.1:10248/healthz",
+			expectedKubeProxyEndpoint: "http://127.0.0.1:12345/healthz",
 		},
 		{
 			name: "HOST_ADDRESS and KUBELET_PORT override supplied",
@@ -141,8 +141,8 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 				"HOST_ADDRESS": "samplehost.testdomain.com",
 				"KUBELET_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:12345",
-			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:10256",
+			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:12345/healthz",
+			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:10256/healthz",
 		},
 		{
 			name: "HOST_ADDRESS and KUBEPROXY_PORT override supplied",
@@ -150,8 +150,8 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 				"HOST_ADDRESS":   "samplehost.testdomain.com",
 				"KUBEPROXY_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:10248",
-			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:12345",
+			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:10248/healthz",
+			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:12345/healthz",
 		},
 		{
 			name: "HOST_ADDRESS, KUBELET_PORT and KUBEPROXY_PORT override supplied",
@@ -160,8 +160,8 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 				"KUBELET_PROXY":  "12345",
 				"KUBEPROXY_PORT": "12346",
 			},
-			expectedKubeletEndpoint:   "http://10.0.10.1:12345",
-			expectedKubeProxyEndpoint: "http://10.0.10.1:12346",
+			expectedKubeletEndpoint:   "http://10.0.10.1:12345/healthz",
+			expectedKubeProxyEndpoint: "http://10.0.10.1:12346/healthz",
 		},
 	}
 	for _, test := range testCases {

--- a/pkg/healthchecker/types/types_test.go
+++ b/pkg/healthchecker/types/types_test.go
@@ -169,9 +169,11 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 			for key, val := range test.envConfig {
 				t.Setenv(key, val)
 			}
+			setKubeEndpoints()
+
 			kubeProxyHCEndpoint := KubeProxyHealthCheckEndpoint()
 			kubeletHCEndpoint := KubeletHealthCheckEndpoint()
-			setKubeEndpoints()
+
 			assert.Equal(t, kubeProxyHCEndpoint, test.expectedKubeProxyEndpoint)
 			assert.Equal(t, kubeletHCEndpoint, test.expectedKubeletEndpoint)
 		})

--- a/pkg/healthchecker/types/types_test.go
+++ b/pkg/healthchecker/types/types_test.go
@@ -109,31 +109,31 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 		{
 			name:                      "no overrides supplied",
 			envConfig:                 map[string]string{},
-			expectedKubeletEndpoint:   "127.0.0.1:10248",
-			expectedKubeProxyEndpoint: "127.0.0.1:10256",
+			expectedKubeletEndpoint:   "http://127.0.0.1:10248",
+			expectedKubeProxyEndpoint: "http://127.0.0.1:10256",
 		}, {
 			name: "HOST_ADDRESS override supplied",
 			envConfig: map[string]string{
 				"HOST_ADDRESS": "samplehost.testdomain.com",
 			},
-			expectedKubeletEndpoint:   "samplehost.testdomain.com:10248",
-			expectedKubeProxyEndpoint: "samplehost.testdomain.com:10256",
+			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:10248",
+			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:10256",
 		},
 		{
 			name: "KUBELET_PORT override supplied",
 			envConfig: map[string]string{
 				"KUBELET_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "127.0.0.1:12345",
-			expectedKubeProxyEndpoint: "127.0.0.1:10256",
+			expectedKubeletEndpoint:   "http://127.0.0.1:12345",
+			expectedKubeProxyEndpoint: "http://127.0.0.1:10256",
 		},
 		{
 			name: "KUBEPROXY_PORT override supplied",
 			envConfig: map[string]string{
 				"KUBEPROXY_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "127.0.0.1:10248",
-			expectedKubeProxyEndpoint: "127.0.0.1:12345",
+			expectedKubeletEndpoint:   "http://127.0.0.1:10248",
+			expectedKubeProxyEndpoint: "http://127.0.0.1:12345",
 		},
 		{
 			name: "HOST_ADDRESS and KUBELET_PORT override supplied",
@@ -141,8 +141,8 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 				"HOST_ADDRESS": "samplehost.testdomain.com",
 				"KUBELET_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "samplehost.testdomain.com:12345",
-			expectedKubeProxyEndpoint: "samplehost.testdomain.com:10256",
+			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:12345",
+			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:10256",
 		},
 		{
 			name: "HOST_ADDRESS and KUBEPROXY_PORT override supplied",
@@ -150,8 +150,8 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 				"HOST_ADDRESS":   "samplehost.testdomain.com",
 				"KUBEPROXY_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "samplehost.testdomain.com:10248",
-			expectedKubeProxyEndpoint: "samplehost.testdomain.com:12345",
+			expectedKubeletEndpoint:   "http://samplehost.testdomain.com:10248",
+			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:12345",
 		},
 		{
 			name: "HOST_ADDRESS, KUBELET_PORT and KUBEPROXY_PORT override supplied",
@@ -160,8 +160,8 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 				"KUBELET_PROXY":  "12345",
 				"KUBEPROXY_PORT": "12346",
 			},
-			expectedKubeletEndpoint:   "10.0.10.1:12345",
-			expectedKubeProxyEndpoint: "10.0.10.1:12346",
+			expectedKubeletEndpoint:   "http://10.0.10.1:12345",
+			expectedKubeProxyEndpoint: "http://10.0.10.1:12346",
 		},
 	}
 	for _, test := range testCases {

--- a/pkg/healthchecker/types/types_test.go
+++ b/pkg/healthchecker/types/types_test.go
@@ -157,7 +157,7 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 			name: "HOST_ADDRESS, KUBELET_PORT and KUBEPROXY_PORT override supplied",
 			envConfig: map[string]string{
 				"HOST_ADDRESS":   "10.0.10.1",
-				"KUBELET_PROXY":  "12345",
+				"KUBELET_PORT":   "12345",
 				"KUBEPROXY_PORT": "12346",
 			},
 			expectedKubeletEndpoint:   "http://10.0.10.1:12345/healthz",

--- a/pkg/healthchecker/types/types_test.go
+++ b/pkg/healthchecker/types/types_test.go
@@ -171,7 +171,7 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 			}
 			kubeProxyHCEndpoint := KubeProxyHealthCheckEndpoint()
 			kubeletHCEndpoint := KubeletHealthCheckEndpoint()
-
+			setKubeEndpoints()
 			assert.Equal(t, kubeProxyHCEndpoint, test.expectedKubeProxyEndpoint)
 			assert.Equal(t, kubeletHCEndpoint, test.expectedKubeletEndpoint)
 		})


### PR DESCRIPTION
# Enable users to optionally provide node's IP and kubelet, kube-proxy ports.

If users do not wish to run node-problem-detector pod in host network mode, or if the kubelet / kube-proxy's ports are modified from its default value for some reason, we should be able to support configuring endpoint accordingly for performing health checks.