### PR TITLE
remove redundant go-get instructions from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,7 @@ For example, to run without auth, use the following config:
 * Install development dependencies for `libsystemd` and the ARM GCC toolchain
   * Debian/Ubuntu: `apt install libsystemd-dev gcc-aarch64-linux-gnu`
 
-* `go get` or `git clone` node-problem-detector repo into `$GOPATH/src/k8s.io` or `$GOROOT/src/k8s.io`
-with one of the below directions:
-  * `cd $GOPATH/src/k8s.io && git clone git@github.com:kubernetes/node-problem-detector.git`
-  * `cd $GOPATH/src/k8s.io && go get k8s.io/node-problem-detector`
+* `git clone git@github.com:kubernetes/node-problem-detector.git`
 
 * Run `make` in the top directory. It will:
   * Build the binary.


### PR DESCRIPTION
fixes https://github.com/kubernetes/node-problem-detector/issues/362

for reproduction started with a clean
```
docker run -v /var/run/docker.sock:/var/run/docker.sock -it --rm golang:1.18-buster bash
curl -fsSL https://get.docker.com | sh
apt install libsystemd-dev gcc-aarch64-linux-gnu
git clone https://github.com/kubernetes/node-problem-detector.git
cd node-problem-detector
make
```