### PR TITLE
Split proc default and validation between Linux and Windows

### DIFF
--- a/pkg/systemstatsmonitor/types/config.go
+++ b/pkg/systemstatsmonitor/types/config.go
@@ -18,7 +18,6 @@ package types
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"time"
 )
@@ -27,7 +26,6 @@ var (
 	defaultInvokeIntervalString   = (60 * time.Second).String()
 	defaultlsblkTimeoutString     = (5 * time.Second).String()
 	defaultKnownModulesConfigPath = "guestosconfig/known-modules.json"
-	defaultProcPath               = "/proc"
 )
 
 type MetricConfig struct {
@@ -135,7 +133,7 @@ func (ssc *SystemStatsConfig) Validate() error {
 	if ssc.InvokeInterval <= time.Duration(0) {
 		return fmt.Errorf("InvokeInterval %v must be above 0s", ssc.InvokeInterval)
 	}
-	if _, err := os.Stat(ssc.ProcPath); err != nil {
+	if err := ssc.validateProcPath(); err != nil {
 		return fmt.Errorf("ProcPath %v check failed: %s", ssc.ProcPath, err)
 	}
 	if ssc.DiskConfig.LsblkTimeout <= time.Duration(0) {

--- a/pkg/systemstatsmonitor/types/config_linux.go
+++ b/pkg/systemstatsmonitor/types/config_linux.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"os"
+)
+
+const defaultProcPath = "/proc"
+
+func (ssc *SystemStatsConfig) validateProcPath() error {
+	_, err := os.Stat(ssc.ProcPath)
+	return err
+}

--- a/pkg/systemstatsmonitor/types/config_windows.go
+++ b/pkg/systemstatsmonitor/types/config_windows.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+const defaultProcPath = ""
+
+func (ssc *SystemStatsConfig) validateProcPath() error {
+	// not supported
+	return nil
+}


### PR DESCRIPTION
#### What does this PR do?

Split procPath default and validation for Windows and Linux.

Linux should default to `/proc` and validate by checking the file exists, while Windows should not have a default nor validation, as this is not supported.

Fixes #747.