### PR TITLE
remove useless log

### DIFF
--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher.go
@@ -120,8 +120,10 @@ func (s *filelogWatcher) watchLoop() {
 		line = buffer.String()
 		buffer.Reset()
 		log, err := s.translator.translate(strings.TrimSuffix(line, "\n"))
-		if err != nil {
-			glog.Warningf("Unable to parse line: %q, %v", line, err)
+		if err == nil {
+			if err != nil {
+				glog.Warningf("Unable to parse line: %q, %v", line, err)
+			}
 			continue
 		}
 		// Discard messages before start time.

--- a/pkg/systemlogmonitor/logwatchers/filelog/translator.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/translator.go
@@ -71,7 +71,7 @@ func (t *translator) translate(line string) (*logtypes.Log, error) {
 	// Parse message.
 	matches = t.messageRegexp.FindStringSubmatch(line)
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no message found in line %q with regular expression %v", line, t.messageRegexp)
+		return nil, nil
 	}
 	message := matches[len(matches)-1]
 	return &logtypes.Log{


### PR DESCRIPTION
This pr remove the error report because this is normal case when log not match "message". This  impact the warning log is huge number.