### PR TITLE
fix: Makefile OS conditional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ junit*.xml
 debug.test
 /output/
 coverage.out
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ IMAGE:=$(REGISTRY)/node-problem-detector:$(TAG)
 # support needs libsystemd-dev or libsystemd-journal-dev.
 ENABLE_JOURNALD?=1
 
-ifeq ($(go env GOHOSTOS), darwin)
+ifeq ($(shell go env GOHOSTOS), darwin)
 ENABLE_JOURNALD=0
-else ifeq ($(go env GOHOSTOS), windows)
+else ifeq ($(shell go env GOHOSTOS), windows)
 ENABLE_JOURNALD=0
 endif
 


### PR DESCRIPTION
Fixes `Makefile` OS conditional preventing build on MacOS for https://github.com/kubernetes/node-problem-detector/issues/752.
