### PR TITLE
Fix Makefile for macOS pt. 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,10 @@ fmt:
 version:
 	@echo $(VERSION)
 
-BINARIES = bin/node-problem-detector bin/health-checker test/bin/problem-maker
+BINARIES = bin/node-problem-detector test/bin/problem-maker
 BINARIES_LINUX_ONLY =
 ifeq ($(ENABLE_JOURNALD), 1)
-	BINARIES_LINUX_ONLY += bin/log-counter
+	BINARIES_LINUX_ONLY += bin/log-counter bin/health-checker # Health checker requires CGO
 endif
 
 ALL_BINARIES = $(foreach binary, $(BINARIES) $(BINARIES_LINUX_ONLY), ./$(binary)) \


### PR DESCRIPTION
This PR moves `bin/health-checker` to the `BINARIES_LINUX_ONLY` variable in the Makefile so that builds can complete successfully on macOS.