### PR TITLE
Fix missing build arg in `build-in-docker` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ build-tar: $(TARBALL) $(ALL_TARBALLS)
 build: build-container build-tar
 
 docker-builder:
-	docker build -t npd-builder . --target=builder
+	docker build -t npd-builder . --target=builder --build-arg BASEIMAGE=$(BASEIMAGE)
 
 build-in-docker: clean docker-builder
 	docker run \


### PR DESCRIPTION
Fixes https://github.com/kubernetes/node-problem-detector/issues/778

Before:
![image](https://github.com/kubernetes/node-problem-detector/assets/2717578/d9950b65-1223-479a-8652-4536829ceaae)

After:
<img width="1368" alt="image" src="https://github.com/kubernetes/node-problem-detector/assets/2717578/a6390ff8-1cd4-4535-aa71-8362a6341ecf">
