### PR TITLE
Update gcb-docker-gcloud image version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
 timeout: 7200s
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230623-56e06d7c18'
     entrypoint: bash
     env:
     - PROW_GIT_TAG=$_GIT_TAG


### PR DESCRIPTION
### What does this PR do?
Update the `gcb-docker-gcloud` image used in cloudbuild.

Looking at the logs from the last failure in job `node-problem-detector-push-images ` (https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/node-problem-detector-push-images/1676633292222238720), I see the following:

```
Building/Pushing NPD containers
--- INSTALLING LIBRARIES ---
OK: 503 MiB in 94 packages
--- RUNNING `make clean` ---
rm -rf bin/
rm -rf test/bin/
rm -f node-problem-detector-*.tar.gz*
rm -rf output/
rm -f coverage.out
--- RUNNING QEMU CONTAINER TO SETUP INTERPRETERS ---
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
[ ... ]
Setting /usr/bin/qemu-hexagon-static as binfmt interpreter for hexagon
--- FAILURE STARTS HERE ---
docker buildx create --use
unknown flag: --use
```

Not sure if this update will fix it, I checked the Docker documentation and the flag usage is correct ([source](https://docs.docker.com/engine/reference/commandline/buildx_create/#use)).