### PR TITLE
add 'node' label to metrics exported by prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible
 	github.com/hpcloud/tail v1.0.0
+	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
 	github.com/prometheus/procfs v0.15.1
@@ -68,7 +69,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
-	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/prometheus v0.35.0 // indirect
 	github.com/prometheus/statsd_exporter v0.22.7 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/pkg/exporters/prometheusexporter/prometheus_exporter.go
+++ b/pkg/exporters/prometheusexporter/prometheus_exporter.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
+	promcli "github.com/prometheus/client_golang/prometheus"
 	"go.opencensus.io/stats/view"
 	"k8s.io/klog/v2"
 
@@ -38,7 +39,9 @@ func NewExporterOrDie(npdo *options.NodeProblemDetectorOptions) types.Exporter {
 	}
 
 	addr := net.JoinHostPort(npdo.PrometheusServerAddress, strconv.Itoa(npdo.PrometheusServerPort))
-	pe, err := prometheus.NewExporter(prometheus.Options{})
+	pe, err := prometheus.NewExporter(prometheus.Options{
+		ConstLabels: promcli.Labels{"node": npdo.NodeName},
+	})
 	if err != nil {
 		klog.Fatalf("Failed to create Prometheus exporter: %v", err)
 	}

--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 			gotMetrics, err := npd.FetchNPDMetrics(instance)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Error fetching NPD metrics: %v", err))
 
-			assertMetricExist(gotMetrics, "cpu_runnable_task_count", map[string]string{}, true)
+			assertMetricExist(gotMetrics, "cpu_runnable_task_count", map[string]string{"node": instance.Name}, true)
 			assertMetricExist(gotMetrics, "cpu_usage_time", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "cpu_load_1m", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "cpu_load_5m", map[string]string{}, false)
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 			assertMetricExist(gotMetrics, "memory_bytes_used", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "memory_anonymous_used", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "memory_page_cache_used", map[string]string{}, false)
-			assertMetricExist(gotMetrics, "memory_unevictable_used", map[string]string{}, true)
+			assertMetricExist(gotMetrics, "memory_unevictable_used", map[string]string{"node": instance.Name}, true)
 			assertMetricExist(gotMetrics, "memory_dirty_used", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "memory_percent_used", map[string]string{}, false)
 			assertMetricExist(gotMetrics, "host_uptime", map[string]string{}, false)
@@ -103,19 +103,19 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Expect NPD to become ready in 120s, but hit error: %v", err))
 
 			assertMetricValueInBound(instance,
-				"problem_gauge", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock"},
+				"problem_gauge", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock", "node": instance.Name},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "DockerHung"},
+				"problem_counter", map[string]string{"reason": "DockerHung", "node": instance.Name},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "FilesystemIsReadOnly"},
+				"problem_counter", map[string]string{"reason": "FilesystemIsReadOnly", "node": instance.Name},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "KernelOops"},
+				"problem_counter", map[string]string{"reason": "KernelOops", "node": instance.Name},
 				0.0, 0.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "OOMKilling"},
+				"problem_counter", map[string]string{"reason": "OOMKilling", "node": instance.Name},
 				0.0, 0.0)
 		})
 	})
@@ -132,10 +132,10 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		ginkgo.It("NPD should update problem_counter{reason:Ext4Error} and problem_gauge{type:ReadonlyFilesystem}", func() {
 			time.Sleep(5 * time.Second)
 			assertMetricValueAtLeast(instance,
-				"problem_counter", map[string]string{"reason": "Ext4Error"},
+				"problem_counter", map[string]string{"reason": "Ext4Error", "node": instance.Name},
 				1.0)
 			assertMetricValueInBound(instance,
-				"problem_gauge", map[string]string{"reason": "FilesystemIsReadOnly", "type": "ReadonlyFilesystem"},
+				"problem_gauge", map[string]string{"reason": "FilesystemIsReadOnly", "type": "ReadonlyFilesystem", "node": instance.Name},
 				1.0, 1.0)
 		})
 
@@ -158,16 +158,16 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		ginkgo.It("NPD should update problem_counter and problem_gauge", func() {
 			time.Sleep(5 * time.Second)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "DockerHung"},
+				"problem_counter", map[string]string{"reason": "DockerHung", "node": instance.Name},
 				1.0, 1.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "TaskHung"},
+				"problem_counter", map[string]string{"reason": "TaskHung", "node": instance.Name},
 				1.0, 1.0)
 			assertMetricValueInBound(instance,
-				"problem_gauge", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock"},
+				"problem_gauge", map[string]string{"reason": "DockerHung", "type": "KernelDeadlock", "node": instance.Name},
 				1.0, 1.0)
 			assertMetricValueInBound(instance,
-				"problem_counter", map[string]string{"reason": "OOMKilling"},
+				"problem_counter", map[string]string{"reason": "OOMKilling", "node": instance.Name},
 				1.0, 1.0)
 		})
 	})


### PR DESCRIPTION
add 'node' label to metrics exported by prometheus.

The metrics obtained from Prometheus do not have node information, which prevents grouping and statistical analysis based on nodes.