### PR TITLE
Monitor XFS shutdown

### DIFF
--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -10,6 +10,11 @@
 			"type": "KernelDeadlock",
 			"reason": "KernelHasNoDeadlock",
 			"message": "kernel has no deadlock"
+		},
+		{
+			"type": "XfsShutdown",
+			"reason": "XfsHasNotShutDown",
+			"message": "XFS has not shutdown"
 		}
 	],
 	"rules": [
@@ -52,6 +57,12 @@
 			"type": "temporary",
 			"reason": "IOError",
 			"pattern": "Buffer I/O error .*"
+		},
+		{
+			"type": "permanent",
+			"condition": "XfsShutdown",
+			"reason": "XfsHasShutdown",
+			"pattern": "XFS .* Shutting down filesystem.?"
 		},
 		{
 			"type": "temporary",


### PR DESCRIPTION
Related kernel error messages are as below.

kernel: XFS (dm-4): Internal error xfs_iunlink_remove at line 2038 of file fs/xfs/xfs_inode.c.  Caller xfs_ifree+0x33/0x130 [xfs]
kernel: XFS (dm-4): Corruption detected. Unmount and run xfs_repair
kernel: XFS (dm-4): xfs_inactive_ifree: xfs_ifree returned error -117
kernel: XFS (dm-4): xfs_do_force_shutdown(0x1) called from line 1788 of file fs/xfs/xfs_inode.c.  Return address = 000000009d022bf1
kernel: XFS (dm-4): I/O Error Detected. Shutting down filesystem
kernel: XFS (dm-4): Please umount the filesystem and rectify the problem(s)