### PR TITLE
fix bug in skip_initial_status

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -125,6 +125,9 @@ func (c *customPluginMonitor) Stop() {
 func (c *customPluginMonitor) monitorLoop() {
 	if !*c.config.PluginGlobalConfig.SkipInitialStatus {
 		c.initializeStatus()
+	} else {
+		c.conditions = initialConditions(c.config.DefaultConditions)
+		klog.Infof("Skipping condition initialization: %+v", c.conditions)
 	}
 
 	resultChan := c.plugin.GetResultChan()


### PR DESCRIPTION
I have found a bug in in the merged PR that introduced the ﻿`skip_initial_status` feature. This bug unjustly leaves conditions stagnant when this feature is enabled in a custom plugin configuration. The root cause is that the conditions for the plugin aren't properly initialized. The PR implies that when `﻿skip_initial_status` is set, the `﻿initialConditions` function is called. As a result, custom plugins with ﻿`skip_initial_status` work correctly.