### PR TITLE
Fix healthchecker execCommand output

### DIFF
--- a/pkg/healthchecker/health_checker.go
+++ b/pkg/healthchecker/health_checker.go
@@ -177,7 +177,7 @@ func execCommand(timeout time.Duration, command string, args ...string) (string,
 	cmd := exec.CommandContext(ctx, command, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		klog.Infof("command %v failed: %v, %v\n", cmd, err, out)
+		klog.Infof("command %v failed: %v, %s\n", cmd, err, string(out))
 		return "", err
 	}
 


### PR DESCRIPTION
https://pkg.go.dev/os/exec#Cmd.CombinedOutput returns `([]byte, error)` so we need to cast the output as string before printing to make it readble. Currently, it prints out the byte slice like below.

```
2024-02-14T21:29:06.921706132Z stderr F  I0214 21:29:06.919561    4052 health_checker.go:89] kubelet is unhealthy, component uptime: 17h51m18.919560214s
2024-02-14T21:29:06.921708048Z stderr F I0214 21:29:06.919610    4052 health_checker.go:91] kubelet cooldown period of 1m0s exceeded, repairing
2024-02-14T21:29:06.921709574Z stderr F I0214 21:29:06.921176    4052 health_checker.go:180] command /bin/systemctl kill --kill-who=main kubelet failed: exit status 1, [70 97 105 108 101 100 32 116 111 32 107 105 108 108 32 117 110 105 116 32 107 117 98 101 108 101 116 46 115 101 114 118 105 99 101 58 32 78 111 32 109 97 105 110 32 112 114 111 99 101 115 115 32 116 111 32 107 105 108 108 10]
```