### PR TITLE
Get Node object from APIServer cache

### DIFF
--- a/pkg/exporters/k8sexporter/problemclient/problem_client.go
+++ b/pkg/exporters/k8sexporter/problemclient/problem_client.go
@@ -130,7 +130,9 @@ func (c *nodeProblemClient) Eventf(eventType, source, reason, messageFmt string,
 }
 
 func (c *nodeProblemClient) GetNode(ctx context.Context) (*v1.Node, error) {
-	return c.client.Nodes().Get(ctx, c.nodeName, metav1.GetOptions{})
+	// To reduce the load on APIServer & etcd, we are serving GET operations from
+	// apiserver cache (the data might be slightly delayed).
+	return c.client.Nodes().Get(ctx, c.nodeName, metav1.GetOptions{ResourceVersion: "0"})
 }
 
 // generatePatch generates condition patch


### PR DESCRIPTION
The risk is pretty low given the returned Node object isn't actually used anywhere - two places invoking GetNode()

1. [k8s_exporter](https://github.com/kubernetes/node-problem-detector/blob/v0.8.15/pkg/exporters/k8sexporter/k8s_exporter.go#L118) calls it to check if readiness but the returned node object is discarded right away
2. [GetConditions](https://github.com/kubernetes/node-problem-detector/blob/v0.8.15/pkg/exporters/k8sexporter/problemclient/problem_client.go#L87), which is not referenced anywhere