### PR TITLE
Revert "Bump NPD versions to v0.8.17"

### DIFF
--- a/deployment/node-problem-detector-healthchecker.yaml
+++ b/deployment/node-problem-detector-healthchecker.yaml
@@ -30,7 +30,7 @@ spec:
         - --logtostderr
         - --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json
         - --config.custom-plugin-monitor=/config/health-checker-kubelet.json
-        image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.17
+        image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.6
         resources:
           limits:
             cpu: 10m

--- a/deployment/node-problem-detector.yaml
+++ b/deployment/node-problem-detector.yaml
@@ -29,7 +29,7 @@ spec:
         - /node-problem-detector
         - --logtostderr
         - --config.system-log-monitor=/config/kernel-monitor.json,/config/docker-monitor.json
-        image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.17
+        image: registry.k8s.io/node-problem-detector/node-problem-detector:v0.8.7
         resources:
           limits:
             cpu: 10m

--- a/pkg/systemstatsmonitor/memory_collector_unix.go
+++ b/pkg/systemstatsmonitor/memory_collector_unix.go
@@ -60,7 +60,7 @@ func (mc *memoryCollector) collect() {
 
 	if mc.mPercentUsed != nil && meminfo.MemTotal != nil && *meminfo.MemTotal > 0 &&
 		meminfo.MemFree != nil && meminfo.Buffers != nil && meminfo.Cached != nil && meminfo.Slab != nil {
-		ratio := float64(*meminfo.MemTotal-*meminfo.MemFree-*meminfo.Buffers-*meminfo.Cached-*meminfo.Slab) / float64(*meminfo.MemTotal)
+		ratio := float64(*meminfo.MemTotal - *meminfo.MemFree - *meminfo.Buffers - *meminfo.Cached - *meminfo.Slab) / float64(*meminfo.MemTotal)
 		mc.mPercentUsed.Record(map[string]string{stateLabel: "used"}, float64(ratio*100.0))
 	}
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -16,7 +16,7 @@ require (
 	k8s.io/apimachinery v0.29.2
 	k8s.io/component-base v0.29.2
 	k8s.io/klog/v2 v2.120.1
-	k8s.io/node-problem-detector v0.8.17
+	k8s.io/node-problem-detector v0.8.14
 	sigs.k8s.io/boskos v0.0.0-20200515170311-7d36bde8cdf6
 )
 

--- a/test/go.sum
+++ b/test/go.sum
@@ -893,6 +893,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
 golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -900,6 +902,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.17.0 h1:6m3ZPmLEFdVxKKWnKq4VqZ60gutO35zm+zrAHVmHyDQ=
+golang.org/x/oauth2 v0.17.0/go.mod h1:OzPDGQiuQMguemayvdylqddI7qcD9lnSDb+1FiwQ5HA=
 golang.org/x/oauth2 v0.18.0 h1:09qnuIAgzdx1XplqJvW6CQqMCtGZykZWcXzPMPUusvI=
 golang.org/x/oauth2 v0.18.0/go.mod h1:Wf7knwG0MPoWIMMBgFlEaSUDaKskp0dCfrlJRJXbBi8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Reverts kubernetes/node-problem-detector#879

Several CI tests fail due to this PR.
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-gci
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-gci-custom-flags
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags