### PR TITLE
Revert "Remove push-tar"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 .PHONY: all \
         vet fmt version test e2e-test \
         build-binaries build-container build-tar build \
-        docker-builder build-in-docker push-container push clean depup
+        docker-builder build-in-docker push-container push-tar push clean depup
 
 all: build
 
@@ -34,6 +34,11 @@ TAG?=$(VERSION)
 
 # REGISTRY is the container registry to push into.
 REGISTRY?=gcr.io/k8s-staging-npd
+
+# UPLOAD_PATH is the cloud storage path to upload release tar.
+UPLOAD_PATH?=gs://kubernetes-release
+# Trim the trailing '/' in the path
+UPLOAD_PATH:=$(shell echo $(UPLOAD_PATH) | sed '$$s/\/*$$//')
 
 # PKG is the package name of node problem detector repo.
 PKG:=k8s.io/node-problem-detector
@@ -259,7 +264,11 @@ endif
 	# Build should be cached from build-container
 	docker buildx build --push --platform $(DOCKER_PLATFORMS) -t $(IMAGE) --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
 
-push: push-container build-tar
+push-tar: build-tar
+	gsutil cp $(TARBALL) $(UPLOAD_PATH)/node-problem-detector/
+	gsutil cp node-problem-detector-$(VERSION)-*.tar.gz* $(UPLOAD_PATH)/node-problem-detector/
+
+push: push-container push-tar
 
 coverage.out:
 	rm -f coverage.out


### PR DESCRIPTION
Reverts kubernetes/node-problem-detector#880

Several CI tests fail due to this PR.
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-gci
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-gci-custom-flags
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu
- https://testgrid.k8s.io/sig-node-node-problem-detector#ci-npd-e2e-kubernetes-gce-ubuntu-custom-flags

We should handle `make push` in the build script https://github.com/kubernetes/node-problem-detector/blob/master/test/build.sh#L141. Reverting this PR first. Will upload another PR with the right fix later.

Ref issue: https://github.com/kubernetes/node-problem-detector/issues/874