### PR TITLE
Add make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@
 .PHONY: all \
         vet fmt version test e2e-test \
         build-binaries build-container build-tar build \
-        docker-builder build-in-docker push-container push-tar push clean depup
+        docker-builder build-in-docker \
+        push-container push-tar push release clean depup
 
 all: build
 
@@ -268,7 +269,11 @@ push-tar: build-tar
 	gsutil cp $(TARBALL) $(UPLOAD_PATH)/node-problem-detector/
 	gsutil cp node-problem-detector-$(VERSION)-*.tar.gz* $(UPLOAD_PATH)/node-problem-detector/
 
+# `make push` is used by presubmit and CI jobs.
 push: push-container push-tar
+
+# `make release` is used when releasing a new NPD version.
+release: push-container build-tar
 
 coverage.out:
 	rm -f coverage.out

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -58,7 +58,7 @@ section to perform steps in this section.**
 sudo  apt-get install libsystemd-dev gcc-aarch64-linux-gnu
 
 cd node-problem-detector
-make push
+make release
 
 # Get SHA256 of the tar files. For example
 sha256sum node-problem-detector-v0.8.17-linux_amd64.tar.gz


### PR DESCRIPTION
Adds a `make release` command for releasing new NPD version. It stops pushing the tar files to gs://kubernetes-release, because no one has write permission to the GCS bucket any more. We haven't pushed NPD tar files to that GCS bucket after v0.8.10. k/k has been using NPD v0.8.13+ since 1.29. NPD release should just include the tar files in the release note.

Ref issue: https://github.com/kubernetes/node-problem-detector/issues/874