### PR TITLE
Add support for CBL-Mariner and Azure Linux

### DIFF
--- a/pkg/util/helpers_linux.go
+++ b/pkg/util/helpers_linux.go
@@ -64,6 +64,10 @@ func getOSVersion(osReleasePath string) (string, error) {
 		return getDebianVersion(osReleaseMap), nil
 	case "sles":
 		return getDebianVersion(osReleaseMap), nil
+	case "mariner":
+		return getDebianVersion(osReleaseMap), nil
+	case "azurelinux":
+		return getDebianVersion(osReleaseMap), nil
 	default:
 		return "", fmt.Errorf("Unsupported ID in /etc/os-release: %q", osReleaseMap["ID"])
 	}

--- a/pkg/util/helpers_linux_test.go
+++ b/pkg/util/helpers_linux_test.go
@@ -76,6 +76,18 @@ func TestGetOSVersionLinux(t *testing.T) {
 			expectErr:         false,
 		},
 		{
+			name:              "mariner",
+			fakeOSReleasePath: "testdata/os-release-mariner",
+			expectedOSVersion: "mariner 2.0.20240123",
+			expectErr:         false,
+		},
+		{
+			name:              "azurelinux",
+			fakeOSReleasePath: "testdata/os-release-azurelinux",
+			expectedOSVersion: "azurelinux 3.0.20240328",
+			expectErr:         false,
+		},
+		{
 			name:              "Unknown",
 			fakeOSReleasePath: "testdata/os-release-unknown",
 			expectedOSVersion: "",

--- a/pkg/util/testdata/os-release-azurelinux
+++ b/pkg/util/testdata/os-release-azurelinux
@@ -1,0 +1,9 @@
+NAME="Microsoft Azure Linux"
+VERSION="3.0.20240328"
+ID=azurelinux
+VERSION_ID="3.0"
+PRETTY_NAME="Microsoft Azure Linux 3.0"
+ANSI_COLOR="1;34"
+HOME_URL="https://aka.ms/azurelinux"
+BUG_REPORT_URL="https://aka.ms/azurelinux"
+SUPPORT_URL="https://aka.ms/azurelinux"

--- a/pkg/util/testdata/os-release-mariner
+++ b/pkg/util/testdata/os-release-mariner
@@ -1,0 +1,9 @@
+NAME="Common Base Linux Mariner"
+VERSION="2.0.20240123"
+ID=mariner
+VERSION_ID="2.0"
+PRETTY_NAME="CBL-Mariner/Linux"
+ANSI_COLOR="1;34"
+HOME_URL="https://aka.ms/cbl-mariner"
+BUG_REPORT_URL="https://aka.ms/cbl-mariner"
+SUPPORT_URL="https://aka.ms/cbl-mariner"


### PR DESCRIPTION
This PR adds support for `mariner` and `azurelinux` in the getOSVersion helper function.

[Azure Linux](https://github.com/microsoft/azurelinux) (aka CBL-Mariner) is a Linux distribution maintained by Microsoft which is currently [available](https://learn.microsoft.com/en-us/azure/aks/use-azure-linux) in Azure Kubernetes Service and is also used in other parts of the cloud infrastructure and edge products. 

For a few years we've been using a [patched](https://github.com/microsoft/azurelinux/blob/592875ba994cf7fc55449f95bfcb3d26f618a50d/SPECS/node-problem-detector/002-add_mariner_OSVersion.patch) version of node-problem-detector which adds Mariner into this switch case. I'm looking to get "mariner" and the upcoming os-release name of "azurelinux" added into node-problem-detector directly so that we can drop the patch and be compatible with instances of the binary built outside of our distro.