### PR TITLE
Update BASEIMAGE to debian-base:bookworm-v1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG BASEIMAGE
 # Must override builder-base, not builder, since the latter is referred to later in the file and so must not be
 # directly replaced. See here, and note that "stage" parameter mentioned there has been renamed to 
 # "build-context": https://github.com/docker/buildx/pull/904#issuecomment-1005871838
-FROM golang:1.22.1-bookworm@sha256:6699d2852712f090399ccd4e8dfd079b4d55376f3ab3aff5b2dc8b7b1c11e27e as builder-base
+FROM golang:1.22.1-bookworm@sha256:d996c645c9934e770e64f05fc2bc103755197b43fd999b3aa5419142e1ee6d78 as builder-base
 FROM builder-base as builder
 LABEL maintainer="Andy Xie <andy.xning@gmail.com>"
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ENABLE_JOURNALD=0
 endif
 
 # Set default base image to Debian 12 (Bookworm)
-BASEIMAGE:=registry.k8s.io/build-image/debian-base:bookworm-v1.0.1
+BASEIMAGE:=registry.k8s.io/build-image/debian-base:bookworm-v1.0.2
 
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0


### PR DESCRIPTION
/cc @wangzhen127 @vteratipally @JohnRusk @geetasg

This should address:
* https://github.com/kubernetes/node-problem-detector/issues/871
* https://github.com/kubernetes/node-problem-detector/issues/887