### PR TITLE
Add helper script to print sha/md5 of tar files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@
         vet fmt version test e2e-test \
         build-binaries build-container build-tar build \
         docker-builder build-in-docker \
-        push-container push-tar push release clean depup
+        push-container push-tar push release clean depup \
+        print-tar-sha-md5
 
 all: build
 
@@ -273,7 +274,10 @@ push-tar: build-tar
 push: push-container push-tar
 
 # `make release` is used when releasing a new NPD version.
-release: push-container build-tar
+release: push-container build-tar print-tar-sha-md5
+
+print-tar-sha-md5: build-tar
+	./hack/print-tar-sha-md5.sh $(VERSION)
 
 coverage.out:
 	rm -f coverage.out

--- a/hack/print-tar-sha-md5.sh
+++ b/hack/print-tar-sha-md5.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION="$1"
+
+NPD_LINUX_AMD64=node-problem-detector-${VERSION}-linux_amd64.tar.gz
+NPD_LINUX_ARM64=node-problem-detector-${VERSION}-linux_arm64.tar.gz
+NPD_WINDOWS_AMD64=node-problem-detector-${VERSION}-windows_amd64.tar.gz
+
+SHA_NPD_LINUX_AMD64=$(sha256sum ${NPD_LINUX_AMD64} | cut -d' ' -f1)
+SHA_NPD_LINUX_ARM64=$(sha256sum ${NPD_LINUX_ARM64} | cut -d' ' -f1)
+SHA_NPD_WINDOWS_AMD64=$(sha256sum ${NPD_WINDOWS_AMD64} | cut -d' ' -f1)
+
+MD5_NPD_LINUX_AMD64=$(md5sum ${NPD_LINUX_AMD64} | cut -d' ' -f1)
+MD5_NPD_LINUX_ARM64=$(md5sum ${NPD_LINUX_ARM64} | cut -d' ' -f1)
+MD5_NPD_WINDOWS_AMD64=$(md5sum ${NPD_WINDOWS_AMD64} | cut -d' ' -f1)
+
+echo
+echo **${NPD_LINUX_AMD64}**:
+echo **SHA**: ${SHA_NPD_LINUX_AMD64}
+echo **MD5**: ${MD5_NPD_LINUX_AMD64}
+echo
+echo **${NPD_LINUX_ARM64}**:
+echo **SHA**: ${SHA_NPD_LINUX_ARM64}
+echo **MD5**: ${MD5_NPD_LINUX_ARM64}
+echo
+echo **${NPD_WINDOWS_AMD64}**:
+echo **SHA**: ${SHA_NPD_WINDOWS_AMD64}
+echo **MD5**: ${MD5_NPD_WINDOWS_AMD64}


### PR DESCRIPTION
During release, there is manual work of generating the sha and md5 values from the built tar. This PR adds the helper script to generate those in markdown format, so that it easier and less error-prone.