### PR TITLE
Skip ext4 e2e tests

### DIFF
--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -130,6 +130,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		})
 
 		ginkgo.It("NPD should update problem_counter{reason:Ext4Error} and problem_gauge{type:ReadonlyFilesystem}", func() {
+			ginkgo.Skip("Writing to /sys/fs/ext4/sda1/trigger_fs_error breaks SSH: https://github.com/kubernetes/node-problem-detector/issues/970")
 			time.Sleep(5 * time.Second)
 			assertMetricValueAtLeast(instance,
 				"problem_counter", map[string]string{"reason": "Ext4Error"},
@@ -140,6 +141,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		})
 
 		ginkgo.It("NPD should remain healthy", func() {
+			ginkgo.Skip("Writing to /sys/fs/ext4/sda1/trigger_fs_error breaks SSH: https://github.com/kubernetes/node-problem-detector/issues/970")
 			npdStates := instance.RunCommandOrFail("sudo systemctl show node-problem-detector -p ActiveState -p SubState")
 			Expect(npdStates.Stdout).To(ContainSubstring("ActiveState=active"), "NPD is no longer active: %v", npdStates)
 			Expect(npdStates.Stdout).To(ContainSubstring("SubState=running"), "NPD is no longer running: %v", npdStates)


### PR DESCRIPTION
Until https://github.com/kubernetes/node-problem-detector/issues/970 is fixed, we should unblock by skipping the affected tests.

/cc @wangzhen127 