### PR TITLE
feat(makefile): add CC switch on GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,12 @@ endif
 # Disable cgo by default to make the binary statically linked.
 CGO_ENABLED:=0
 
+ifeq ($(GOARCH), arm64)
+	CC:=aarch64-linux-gnu-gcc
+else
+	CC:=gcc
+endif
+
 # Set default Go architecture to AMD64.
 GOARCH ?= amd64
 
@@ -181,7 +187,7 @@ output/linux_arm64/test/bin/%: $(PKG_SOURCES)
 # In the future these targets should be deprecated.
 ./bin/log-counter: $(PKG_SOURCES)
 ifeq ($(ENABLE_JOURNALD), 1)
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) CC=$(CC) go build \
 		-o bin/log-counter \
 		-ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
 		-tags "$(LINUX_BUILD_TAGS)" \
@@ -191,7 +197,7 @@ else
 endif
 
 ./bin/node-problem-detector: $(PKG_SOURCES)
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) CC=$(CC) go build \
 		-o bin/node-problem-detector \
 		-ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
 		-tags "$(LINUX_BUILD_TAGS)" \
@@ -199,13 +205,13 @@ endif
 
 ./test/bin/problem-maker: $(PKG_SOURCES)
 	cd test && \
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) CC=$(CC) go build \
 		-o bin/problem-maker \
 		-tags "$(LINUX_BUILD_TAGS)" \
 		./e2e/problemmaker/problem_maker.go
 
 ./bin/health-checker: $(PKG_SOURCES)
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) go build \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) CC=$(CC) go build \
 		-o bin/health-checker \
 		-ldflags '-X $(PKG)/pkg/version.version=$(VERSION)' \
 		-tags "$(LINUX_BUILD_TAGS)" \

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ CGO_ENABLED:=0
 ifeq ($(GOARCH), arm64)
 	CC:=aarch64-linux-gnu-gcc
 else
-	CC:=gcc
+	CC:=x86_64-linux-gnu-gcc
 endif
 
 # Set default Go architecture to AMD64.


### PR DESCRIPTION
This PR adds an ifdef to set the CC variable when GOARCH is arm64 and not default.

With the current Makefile as written, `GOARCH=arm64 make build-binaries` fails if building on amd64 systems (or in amd64 containers) 

```
»  GOARCH=arm64 make build-binaries
CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build \
	-o bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16' \
	-tags "journald " \
	./cmd/nodeproblemdetector
# runtime/cgo
gcc_arm64.S: Assembler messages:
gcc_arm64.S:30: Error: no such instruction: `stp x29,x30,[sp,'
gcc_arm64.S:34: Error: too many memory references for `mov'
gcc_arm64.S:36: Error: no such instruction: `stp x19,x20,[sp,'
gcc_arm64.S:39: Error: no such instruction: `stp x21,x22,[sp,'
gcc_arm64.S:42: Error: no such instruction: `stp x23,x24,[sp,'
gcc_arm64.S:45: Error: no such instruction: `stp x25,x26,[sp,'
gcc_arm64.S:48: Error: no such instruction: `stp x27,x28,[sp,'
gcc_arm64.S:52: Error: too many memory references for `mov'
gcc_arm64.S:53: Error: too many memory references for `mov'
gcc_arm64.S:54: Error: too many memory references for `mov'
gcc_arm64.S:56: Error: no such instruction: `blr x20'
gcc_arm64.S:57: Error: no such instruction: `blr x19'
gcc_arm64.S:59: Error: no such instruction: `ldp x27,x28,[sp,'
gcc_arm64.S:62: Error: no such instruction: `ldp x25,x26,[sp,'
gcc_arm64.S:65: Error: no such instruction: `ldp x23,x24,[sp,'
gcc_arm64.S:68: Error: no such instruction: `ldp x21,x22,[sp,'
gcc_arm64.S:71: Error: no such instruction: `ldp x19,x20,[sp,'
gcc_arm64.S:74: Error: no such instruction: `ldp x29,x30,[sp],'
make: *** [Makefile:195: bin/node-problem-detector] Error 1
```

with the Makefile in this PR:

```
»  GOARCH=arm64 make build-binaries
CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build \
	-o bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/nodeproblemdetector
CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build \
	-o bin/health-checker \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	cmd/healthchecker/health_checker.go
cd test && \
CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build \
	-o bin/problem-maker \
	-tags "journald " \
	./e2e/problemmaker/problem_maker.go
CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build \
	-o bin/log-counter \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	cmd/logcounter/log_counter.go
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o output/linux_amd64/bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/nodeproblemdetector
touch output/linux_amd64/bin/node-problem-detector
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o output/linux_amd64/bin/health-checker \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/healthchecker
touch output/linux_amd64/bin/health-checker
cd test && \
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o ../output/linux_amd64/test/bin/problem-maker \
	-tags "journald " \
	./e2e/problemmaker
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o output/linux_amd64/bin/log-counter \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/logcounter
touch output/linux_amd64/bin/log-counter
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o output/linux_arm64/bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/nodeproblemdetector
touch output/linux_arm64/bin/node-problem-detector
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o output/linux_arm64/bin/health-checker \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/healthchecker
touch output/linux_arm64/bin/health-checker
cd test && \
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o ../output/linux_arm64/test/bin/problem-maker \
	-tags "journald " \
	./e2e/problemmaker
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o output/linux_arm64/bin/log-counter \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/logcounter
touch output/linux_arm64/bin/log-counter
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build \
	-o output/windows_amd64/bin/node-problem-detector.exe \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "" \
	./cmd/nodeproblemdetector
touch output/windows_amd64/bin/node-problem-detector.exe
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build \
	-o output/windows_amd64/bin/health-checker.exe \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "" \
	./cmd/healthchecker
touch output/windows_amd64/bin/health-checker.exe
cd test && \
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build \
	-o ../output/windows_amd64/test/bin/problem-maker.exe \
	-tags "" \
	./e2e/problemmaker
```

amd64 build / GOARCH not set (using defaults):
```
»  make build-binaries
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc go build \
	-o bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/nodeproblemdetector
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc go build \
	-o bin/health-checker \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	cmd/healthchecker/health_checker.go
cd test && \
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc go build \
	-o bin/problem-maker \
	-tags "journald " \
	./e2e/problemmaker/problem_maker.go
CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc go build \
	-o bin/log-counter \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	cmd/logcounter/log_counter.go
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o output/linux_amd64/bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/nodeproblemdetector
touch output/linux_amd64/bin/node-problem-detector
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o output/linux_amd64/bin/health-checker \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/healthchecker
touch output/linux_amd64/bin/health-checker
cd test && \
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o ../output/linux_amd64/test/bin/problem-maker \
	-tags "journald " \
	./e2e/problemmaker
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
  CC=x86_64-linux-gnu-gcc go build \
	-o output/linux_amd64/bin/log-counter \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/logcounter
touch output/linux_amd64/bin/log-counter
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o output/linux_arm64/bin/node-problem-detector \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/nodeproblemdetector
touch output/linux_arm64/bin/node-problem-detector
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o output/linux_arm64/bin/health-checker \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/healthchecker
touch output/linux_arm64/bin/health-checker
cd test && \
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o ../output/linux_arm64/test/bin/problem-maker \
	-tags "journald " \
	./e2e/problemmaker
GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
  CC=aarch64-linux-gnu-gcc go build \
	-o output/linux_arm64/bin/log-counter \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "journald " \
	./cmd/logcounter
touch output/linux_arm64/bin/log-counter
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build \
	-o output/windows_amd64/bin/node-problem-detector.exe \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "" \
	./cmd/nodeproblemdetector
touch output/windows_amd64/bin/node-problem-detector.exe
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build \
	-o output/windows_amd64/bin/health-checker.exe \
	-ldflags '-X k8s.io/node-problem-detector/pkg/version.version=v0.8.16-dirty' \
	-tags "" \
	./cmd/healthchecker
touch output/windows_amd64/bin/health-checker.exe
cd test && \
GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go build \
	-o ../output/windows_amd64/test/bin/problem-maker.exe \
	-tags "" \
	./e2e/problemmaker
```
👍 