### PR TITLE
feat(k8sexporter/problemclient): allow deletion of deprecated condition types

### DIFF
--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -88,6 +88,9 @@ type NodeProblemDetectorOptions struct {
 	MonitorConfigPaths types.ProblemDaemonConfigPathMap
 
 	// application options
+	// DeleteDeprecatedConditions is the flag determining whether to delete deprecated Conditions and Events from the node status.
+	DeleteDeprecatedConditions bool
+	DeprecatedConditionTypes   []string
 
 	// NodeName is the node name used to communicate with Kubernetes ApiServer.
 	NodeName string
@@ -131,6 +134,8 @@ func (npdo *NodeProblemDetectorOptions) AddFlags(fs *pflag.FlagSet) {
 		"127.0.0.1", "The address to bind the Prometheus scrape endpoint.")
 	fs.Float32Var(&npdo.QPS, "kube-api-qps", 500, "Maximum QPS to use while talking with Kubernetes API")
 	fs.IntVar(&npdo.Burst, "kube-api-burst", 500, "Maximum burst for throttle while talking with Kubernetes API")
+	fs.BoolVar(&npdo.DeleteDeprecatedConditions, "delete-deprecated-conditions", false, "Whether to delete deprecated Conditions and Events from the node status")
+	fs.StringSliceVar(&npdo.DeprecatedConditionTypes, "deprecated-condition-types", []string{}, "List of deprecated condition types to delete. This is ignored if --delete-deprecated-conditions is false.")
 	for _, exporterName := range exporters.GetExporterNames() {
 		exporterHandler := exporters.GetExporterHandlerOrDie(exporterName)
 		exporterHandler.Options.SetFlags(fs)

--- a/pkg/exporters/k8sexporter/k8s_exporter.go
+++ b/pkg/exporters/k8sexporter/k8s_exporter.go
@@ -63,6 +63,12 @@ func NewExporterOrDie(ctx context.Context, npdo *options.NodeProblemDetectorOpti
 	}
 
 	ke.startHTTPReporting(npdo)
+	if npdo.DeleteDeprecatedConditions {
+		err := ke.client.DeleteDeprecatedConditions(ctx, npdo.DeprecatedConditionTypes)
+		if err != nil {
+			klog.Errorf("Failed to delete deprecated conditions: %v", err)
+		}
+	}
 	ke.conditionManager.Start(ctx)
 
 	return &ke

--- a/pkg/exporters/k8sexporter/problemclient/fake_problem_client.go
+++ b/pkg/exporters/k8sexporter/problemclient/fake_problem_client.go
@@ -60,6 +60,18 @@ func (f *FakeProblemClient) AssertConditions(expected []v1.NodeCondition) error 
 	return nil
 }
 
+// DeleteDeprecatedConditions is a fake mimic of DeleteDeprecatedConditions, it only delete the internal condition cache.
+func (f *FakeProblemClient) DeleteDeprecatedConditions(ctx context.Context, types []string) error {
+	if err, ok := f.errors["DeleteDeprecatedConditions"]; ok {
+		return err
+	}
+	realTypes := generateConditionTypes(types)
+	for _, t := range realTypes {
+		delete(f.conditions, t)
+	}
+	return nil
+}
+
 // SetConditions is a fake mimic of SetConditions, it only update the internal condition cache.
 func (f *FakeProblemClient) SetConditions(ctx context.Context, conditions []v1.NodeCondition) error {
 	f.Lock()


### PR DESCRIPTION
this PR adds two flags,

1. enable deprecated condition type deletion (bool, defaults to false)
2. a CSV-string of condition type names to delete (string, ignored if 1 is false)

if enabled and given a string, on problemclient initialization we loop over the .status.conditions field of our node and recreate the list without the types present in the new switch (2) outlined above. we `update` .status.conditions with the new list (patching doesn't work here)

closes #1011 