### PR TITLE
imagePullPolicy doesn't need to be set to Always

### DIFF
--- a/deployment/node-problem-detector-healthchecker.yaml
+++ b/deployment/node-problem-detector-healthchecker.yaml
@@ -38,7 +38,7 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         env:

--- a/deployment/node-problem-detector.yaml
+++ b/deployment/node-problem-detector.yaml
@@ -37,7 +37,7 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
Since images are pinned to specific versions, setting `imagePullPolicy` to `Always` is needlessly wasteful. Changing to the default `IfNotPresent` instead.