### PR TITLE
feat!: Set default host address value to `localhost`.

### DIFF
--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"sort"
 	"strconv"
@@ -44,7 +45,7 @@ const (
 	kubeletPortKey          = "KUBELET_PORT"
 	kubeProxyPortKey        = "KUBEPROXY_PORT"
 
-	defaultHostAddress   = "127.0.0.1"
+	defaultHostAddress   = "localhost"
 	defaultKubeletPort   = "10248"
 	defaultKubeproxyPort = "10256"
 )
@@ -78,8 +79,8 @@ func setKubeEndpoints() {
 		kubeProxyPort = o
 	}
 
-	kubeletHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostAddress, kubeletPort)
-	kubeProxyHealthCheckEndpoint = fmt.Sprintf("http://%s:%s/healthz", hostAddress, kubeProxyPort)
+	kubeletHealthCheckEndpoint = fmt.Sprintf("http://%s/healthz", net.JoinHostPort(hostAddress, kubeletPort))
+	kubeProxyHealthCheckEndpoint = fmt.Sprintf("http://%s/healthz", net.JoinHostPort(hostAddress, kubeProxyPort))
 
 }
 

--- a/pkg/healthchecker/types/types_test.go
+++ b/pkg/healthchecker/types/types_test.go
@@ -109,9 +109,10 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 		{
 			name:                      "no overrides supplied",
 			envConfig:                 map[string]string{},
-			expectedKubeletEndpoint:   "http://127.0.0.1:10248/healthz",
-			expectedKubeProxyEndpoint: "http://127.0.0.1:10256/healthz",
-		}, {
+			expectedKubeletEndpoint:   "http://localhost:10248/healthz",
+			expectedKubeProxyEndpoint: "http://localhost:10256/healthz",
+		},
+		{
 			name: "HOST_ADDRESS override supplied",
 			envConfig: map[string]string{
 				"HOST_ADDRESS": "samplehost.testdomain.com",
@@ -120,20 +121,36 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 			expectedKubeProxyEndpoint: "http://samplehost.testdomain.com:10256/healthz",
 		},
 		{
+			name: "HOST_ADDRESS override supplied with IPv4",
+			envConfig: map[string]string{
+				"HOST_ADDRESS": "10.0.5.4",
+			},
+			expectedKubeletEndpoint:   "http://10.0.5.4:10248/healthz",
+			expectedKubeProxyEndpoint: "http://10.0.5.4:10256/healthz",
+		},
+		{
+			name: "HOST_ADDRESS override supplied with IPv6",
+			envConfig: map[string]string{
+				"HOST_ADDRESS": "80:f4:16::1",
+			},
+			expectedKubeletEndpoint:   "http://[80:f4:16::1]:10248/healthz",
+			expectedKubeProxyEndpoint: "http://[80:f4:16::1]:10256/healthz",
+		},
+		{
 			name: "KUBELET_PORT override supplied",
 			envConfig: map[string]string{
 				"KUBELET_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "http://127.0.0.1:12345/healthz",
-			expectedKubeProxyEndpoint: "http://127.0.0.1:10256/healthz",
+			expectedKubeletEndpoint:   "http://localhost:12345/healthz",
+			expectedKubeProxyEndpoint: "http://localhost:10256/healthz",
 		},
 		{
 			name: "KUBEPROXY_PORT override supplied",
 			envConfig: map[string]string{
 				"KUBEPROXY_PORT": "12345",
 			},
-			expectedKubeletEndpoint:   "http://127.0.0.1:10248/healthz",
-			expectedKubeProxyEndpoint: "http://127.0.0.1:12345/healthz",
+			expectedKubeletEndpoint:   "http://localhost:10248/healthz",
+			expectedKubeProxyEndpoint: "http://localhost:12345/healthz",
 		},
 		{
 			name: "HOST_ADDRESS and KUBELET_PORT override supplied",
@@ -174,8 +191,8 @@ func TestKubeEndpointConfiguration(t *testing.T) {
 			kubeProxyHCEndpoint := KubeProxyHealthCheckEndpoint()
 			kubeletHCEndpoint := KubeletHealthCheckEndpoint()
 
-			assert.Equal(t, kubeProxyHCEndpoint, test.expectedKubeProxyEndpoint)
-			assert.Equal(t, kubeletHCEndpoint, test.expectedKubeletEndpoint)
+			assert.Equal(t, test.expectedKubeProxyEndpoint, kubeProxyHCEndpoint)
+			assert.Equal(t, test.expectedKubeletEndpoint, kubeletHCEndpoint)
 		})
 	}
 }


### PR DESCRIPTION
Usage of `localhost` is family agnostic and will work regardless if cluster is IPv4 or IPv6. The current value of `127.0.0.1` only works for IPv4 clusters.

BREAKING CHANGE: It may break in rare cases where `localhost` does not resolve as `127.0.0.1` (if OS config does not follow RFC5735 and RFC6761).

Fixes #1060.