### PR TITLE
Update golang version to 1.24.4 as CVE fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/node-problem-detector
 
-go 1.24.2
+go 1.24.4
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/node-problem-detector/test
 
-go 1.24.2
+go 1.24.4
 
 replace k8s.io/node-problem-detector => ../.
 


### PR DESCRIPTION
Updating golang version as a fix to:
- CVE-2025-22874
- CVE-2025-0913
- CVE-2025-4673