### PR TITLE
Fix test instance name

### DIFF
--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -130,6 +130,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		})
 
 		ginkgo.It("NPD should update problem_counter{reason:Ext4Error} and problem_gauge{type:ReadonlyFilesystem}", func() {
+			ginkgo.Skip("Writing to /sys/fs/ext4/sda1/trigger_fs_error breaks SSH: https://github.com/kubernetes/node-problem-detector/issues/970")
 			time.Sleep(5 * time.Second)
 			assertMetricValueAtLeast(instance,
 				"problem_counter", map[string]string{"reason": "Ext4Error"},
@@ -140,6 +141,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		})
 
 		ginkgo.It("NPD should remain healthy", func() {
+			ginkgo.Skip("Writing to /sys/fs/ext4/sda1/trigger_fs_error breaks SSH: https://github.com/kubernetes/node-problem-detector/issues/970")
 			npdStates := instance.RunCommandOrFail("sudo systemctl show node-problem-detector -p ActiveState -p SubState")
 			Expect(npdStates.Stdout).To(ContainSubstring("ActiveState=active"), "NPD is no longer active: %v", npdStates)
 			Expect(npdStates.Stdout).To(ContainSubstring("SubState=running"), "NPD is no longer running: %v", npdStates)

--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		}
 		instance, err = gce.CreateInstance(
 			gce.Instance{
-				Name:           "npd-metrics-" + *image + "-" + uuid.NewUUID().String()[:8],
+				Name:           "npd-metrics-" + uuid.NewUUID().String()[:8],
 				Zone:           *zone,
 				Project:        *project,
 				SshKey:         *sshKey,


### PR DESCRIPTION
```
Unable to create test instance: could not create instance npd-metrics-ubuntu-gke-2404-1-33-amd64-v20250810-cgroupsv1-9efd5f13:
API error: googleapi: Error 400: Invalid value for field 'resource.name': 'npd-metrics-ubuntu-gke-2404-1-33-amd64-v20250810-cgroupsv1-9efd5f13'.
Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)', invalid
```