### PR TITLE
format imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,20 @@ issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
+    goimports:
+      local-prefixes:
+        - k8s.io/node-problem-detector
   exclusions:
     generated: lax
     paths:

--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,9 @@ vet:
 		grep -v "./vendor/*" | \
 		xargs go vet -tags "$(HOST_PLATFORM_BUILD_TAGS)"
 
-fmt:
+fmt: $(GOLANGCI_LINT)
 	find . -type f -name "*.go" | grep -v "./vendor/*" | xargs gofmt -s -w -l
+	$(GOLANGCI_LINT) run --config .golangci.yml --fix ./...
 
 version:
 	@echo $(VERSION)

--- a/cmd/healthchecker/health_checker.go
+++ b/cmd/healthchecker/health_checker.go
@@ -22,8 +22,8 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-
 	"k8s.io/klog/v2"
+
 	"k8s.io/node-problem-detector/cmd/healthchecker/options"
 	"k8s.io/node-problem-detector/pkg/custompluginmonitor/types"
 	"k8s.io/node-problem-detector/pkg/healthchecker"

--- a/cmd/nodeproblemdetector/node_problem_detector_test.go
+++ b/cmd/nodeproblemdetector/node_problem_detector_test.go
@@ -71,8 +71,7 @@ func init() {
 	})
 }
 
-type nullExporter struct {
-}
+type nullExporter struct{}
 
 func (ne *nullExporter) ExportProblems(*types.Status) {
 }
@@ -96,7 +95,7 @@ func writeTempFile(t *testing.T, ext string, contents string) (string, error) {
 
 	fileName := f.Name()
 
-	if err := os.WriteFile(fileName, []byte(contents), 0644); err != nil {
+	if err := os.WriteFile(fileName, []byte(contents), 0o644); err != nil {
 		os.Remove(fileName)
 		return "", fmt.Errorf("cannot write config to temp file %s, %v", fileName, err)
 	}

--- a/cmd/nodeproblemdetector/node_problem_detector_unix.go
+++ b/cmd/nodeproblemdetector/node_problem_detector_unix.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
+
 	"k8s.io/node-problem-detector/cmd/options"
 )
 

--- a/cmd/options/options.go
+++ b/cmd/options/options.go
@@ -19,10 +19,9 @@ package options
 import (
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
-
-	"net/url"
 
 	"github.com/spf13/pflag"
 

--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -39,7 +39,8 @@ func init() {
 		CustomPluginMonitorName,
 		types.ProblemDaemonHandler{
 			CreateProblemDaemonOrDie: NewCustomPluginMonitorOrDie,
-			CmdOptionDescription:     "Set to config file paths."})
+			CmdOptionDescription:     "Set to config file paths.",
+		})
 }
 
 type customPluginMonitor struct {

--- a/pkg/custompluginmonitor/plugin/plugin.go
+++ b/pkg/custompluginmonitor/plugin/plugin.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+
 	cpmtypes "k8s.io/node-problem-detector/pkg/custompluginmonitor/types"
 	"k8s.io/node-problem-detector/pkg/util"
 	"k8s.io/node-problem-detector/pkg/util/tomb"

--- a/pkg/custompluginmonitor/types/config_test.go
+++ b/pkg/custompluginmonitor/types/config_test.go
@@ -197,9 +197,10 @@ func TestCustomPluginConfigApplyConfiguration(t *testing.T) {
 			},
 		},
 		"disable status update during initialization": {
-			Orig: CustomPluginConfig{PluginGlobalConfig: pluginGlobalConfig{
-				SkipInitialStatus: &disableInitialStatusUpdate,
-			},
+			Orig: CustomPluginConfig{
+				PluginGlobalConfig: pluginGlobalConfig{
+					SkipInitialStatus: &disableInitialStatusUpdate,
+				},
 			},
 			Wanted: CustomPluginConfig{
 				PluginGlobalConfig: pluginGlobalConfig{

--- a/pkg/exporters/k8sexporter/condition/manager.go
+++ b/pkg/exporters/k8sexporter/condition/manager.go
@@ -22,14 +22,13 @@ import (
 	"sync"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+
 	"k8s.io/node-problem-detector/pkg/exporters/k8sexporter/problemclient"
 	"k8s.io/node-problem-detector/pkg/types"
 	problemutil "k8s.io/node-problem-detector/pkg/util"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/utils/clock"
-
-	"k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/exporters/k8sexporter/condition/manager_test.go
+++ b/pkg/exporters/k8sexporter/condition/manager_test.go
@@ -23,13 +23,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	testclock "k8s.io/utils/clock/testing"
 
 	"k8s.io/node-problem-detector/pkg/exporters/k8sexporter/problemclient"
 	"k8s.io/node-problem-detector/pkg/types"
 	problemutil "k8s.io/node-problem-detector/pkg/util"
-
-	v1 "k8s.io/api/core/v1"
-	testclock "k8s.io/utils/clock/testing"
 )
 
 const heartbeatPeriod = 1 * time.Minute

--- a/pkg/exporters/k8sexporter/k8s_exporter.go
+++ b/pkg/exporters/k8sexporter/k8s_exporter.go
@@ -23,9 +23,8 @@ import (
 	"net/http/pprof"
 	"strconv"
 
-	"k8s.io/klog/v2"
-
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 
 	"k8s.io/node-problem-detector/cmd/options"

--- a/pkg/exporters/k8sexporter/problemclient/problem_client_test.go
+++ b/pkg/exporters/k8sexporter/problemclient/problem_client_test.go
@@ -22,12 +22,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	testclock "k8s.io/utils/clock/testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/pkg/exporters/register.go
+++ b/pkg/exporters/register.go
@@ -22,9 +22,7 @@ import (
 	"k8s.io/node-problem-detector/pkg/types"
 )
 
-var (
-	handlers = make(map[types.ExporterType]types.ExporterHandler)
-)
+var handlers = make(map[types.ExporterType]types.ExporterHandler)
 
 // Register registers a exporter factory method, which will be used to create the exporter.
 func Register(exporterType types.ExporterType, handler types.ExporterHandler) {

--- a/pkg/exporters/stackdriver/stackdriver_exporter.go
+++ b/pkg/exporters/stackdriver/stackdriver_exporter.go
@@ -25,12 +25,12 @@ import (
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	monitoredres "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
+	"github.com/avast/retry-go/v4"
 	"github.com/spf13/pflag"
 	"go.opencensus.io/stats/view"
 	"google.golang.org/api/option"
 	"k8s.io/klog/v2"
 
-	"github.com/avast/retry-go/v4"
 	"k8s.io/node-problem-detector/pkg/exporters"
 	seconfig "k8s.io/node-problem-detector/pkg/exporters/stackdriver/config"
 	"k8s.io/node-problem-detector/pkg/types"
@@ -41,7 +41,8 @@ func init() {
 	clo := commandLineOptions{}
 	exporters.Register(exporterName, types.ExporterHandler{
 		CreateExporterOrDie: NewExporterOrDie,
-		Options:             &clo})
+		Options:             &clo,
+	})
 }
 
 const exporterName = "stackdriver"
@@ -95,7 +96,6 @@ var NPDMetricToSDMetric = map[metrics.MetricID]string{
 }
 
 func getMetricTypeConversionFunction(customMetricPrefix string) func(*view.View) string {
-
 	return func(view *view.View) string {
 		viewName := view.Measure.Name()
 

--- a/pkg/healthchecker/health_checker.go
+++ b/pkg/healthchecker/health_checker.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+
 	"k8s.io/node-problem-detector/cmd/healthchecker/options"
 	"k8s.io/node-problem-detector/pkg/healthchecker/types"
 )

--- a/pkg/healthchecker/health_checker_linux.go
+++ b/pkg/healthchecker/health_checker_linux.go
@@ -38,7 +38,6 @@ func getUptimeFunc(service string) func() (time.Duration, error) {
 		// RestartSec of systemd and invoke interval of plugin got in sync. The service was repeatedly killed in
 		// activating state and hence ActiveEnterTimestamp was never updated.
 		out, err := execCommand(types.CmdTimeout, "systemctl", "show", service, "--property=InactiveExitTimestamp")
-
 		if err != nil {
 			return time.Duration(0), err
 		}

--- a/pkg/healthchecker/health_checker_test.go
+++ b/pkg/healthchecker/health_checker_test.go
@@ -150,8 +150,6 @@ func TestComponentsSupported(t *testing.T) {
 			if checkFunc == nil {
 				t.Errorf("component %v should be supported", tc.component)
 			}
-
 		})
 	}
-
 }

--- a/pkg/healthchecker/types/types.go
+++ b/pkg/healthchecker/types/types.go
@@ -81,12 +81,12 @@ func setKubeEndpoints() {
 
 	kubeletHealthCheckEndpoint = fmt.Sprintf("http://%s/healthz", net.JoinHostPort(hostAddress, kubeletPort))
 	kubeProxyHealthCheckEndpoint = fmt.Sprintf("http://%s/healthz", net.JoinHostPort(hostAddress, kubeProxyPort))
-
 }
 
 func KubeProxyHealthCheckEndpoint() string {
 	return kubeProxyHealthCheckEndpoint
 }
+
 func KubeletHealthCheckEndpoint() string {
 	return kubeletHealthCheckEndpoint
 }

--- a/pkg/problemdaemon/problem_daemon.go
+++ b/pkg/problemdaemon/problem_daemon.go
@@ -24,9 +24,7 @@ import (
 	"k8s.io/node-problem-detector/pkg/types"
 )
 
-var (
-	handlers = make(map[types.ProblemDaemonType]types.ProblemDaemonHandler)
-)
+var handlers = make(map[types.ProblemDaemonType]types.ProblemDaemonHandler)
 
 // Register registers a problem daemon factory method, which will be used to create the problem daemon.
 func Register(problemDaemonType types.ProblemDaemonType, handler types.ProblemDaemonHandler) {

--- a/pkg/systemlogmonitor/log_monitor.go
+++ b/pkg/systemlogmonitor/log_monitor.go
@@ -41,7 +41,8 @@ func init() {
 		SystemLogMonitorName,
 		types.ProblemDaemonHandler{
 			CreateProblemDaemonOrDie: NewLogMonitorOrDie,
-			CmdOptionDescription:     "Set to config file paths."})
+			CmdOptionDescription:     "Set to config file paths.",
+		})
 }
 
 type logMonitor struct {

--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher.go
@@ -134,7 +134,7 @@ func (s *filelogWatcher) watchLoop() {
 }
 
 func (s *filelogWatcher) filterSkipList(line string) bool {
-	for _ , skipItem := range s.cfg.SkipList {
+	for _, skipItem := range s.cfg.SkipList {
 		if strings.Contains(line, skipItem) {
 			return true
 		}

--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_linux.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_linux.go
@@ -19,8 +19,9 @@ package filelog
 import (
 	"fmt"
 	"io"
-	"k8s.io/node-problem-detector/third_party/forked/cadvisor/tail"
 	"os"
+
+	"k8s.io/node-problem-detector/third_party/forked/cadvisor/tail"
 )
 
 // getLogReader returns log reader for filelog log. Note that getLogReader doesn't look back

--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_test.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	testclock "k8s.io/utils/clock/testing"
+
 	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
 	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
 	"k8s.io/node-problem-detector/pkg/util"
-
-	"github.com/stretchr/testify/assert"
-	testclock "k8s.io/utils/clock/testing"
 )
 
 // getTestPluginConfig returns a plugin config for test. Use configuration for
@@ -185,22 +185,21 @@ func TestFilterSkipList(t *testing.T) {
 			},
 		},
 	}
-	testcase := []struct{
-		log string
+	testcase := []struct {
+		log    string
 		expect bool
 	}{
 		{
-			log: `Jan  2 03:04:03 kernel: [0.000000] 1`,
+			log:    `Jan  2 03:04:03 kernel: [0.000000] 1`,
 			expect: false,
 		},
 		{
-			log: `Jan  2 03:04:04 audit: [1.000000] 2`,
+			log:    `Jan  2 03:04:04 audit: [1.000000] 2`,
 			expect: true,
 		},
 		{
-			log: `Jan  2 03:04:05 kubelet: [2.000000] 3`,
+			log:    `Jan  2 03:04:05 kubelet: [2.000000] 3`,
 			expect: true,
-
 		},
 	}
 	for i, test := range testcase {

--- a/pkg/systemlogmonitor/logwatchers/filelog/translator.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/translator.go
@@ -20,9 +20,9 @@ import (
 	"regexp"
 	"time"
 
-	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
-
 	"k8s.io/klog/v2"
+
+	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
 )
 
 // translator translates log line into internal log type based on user defined

--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux_test.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package kmsg
 
 import (
-	testclock "k8s.io/utils/clock/testing"
 	"testing"
+	"time"
 
 	"github.com/euank/go-kmsg-parser/kmsgparser"
 	"github.com/stretchr/testify/assert"
-	"time"
+	testclock "k8s.io/utils/clock/testing"
 
 	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
 	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"

--- a/pkg/systemlogmonitor/logwatchers/log_watchers.go
+++ b/pkg/systemlogmonitor/logwatchers/log_watchers.go
@@ -17,9 +17,9 @@ limitations under the License.
 package logwatchers
 
 import (
-	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
-
 	"k8s.io/klog/v2"
+
+	"k8s.io/node-problem-detector/pkg/systemlogmonitor/logwatchers/types"
 )
 
 // createFuncs is a table of createFuncs for all supported log watchers.

--- a/pkg/systemstatsmonitor/disk_collector.go
+++ b/pkg/systemstatsmonitor/disk_collector.go
@@ -307,7 +307,6 @@ func (dc *diskCollector) collect() {
 			dc.mPercentUsed.Record(map[string]string{deviceNameLabel: deviceName, fsTypeLabel: fstype, mountOptionLabel: opttypes, stateLabel: "used"}, float64(usageStat.UsedPercent))
 		}
 	}
-
 }
 
 // listRootBlockDevices lists all block devices that's not a slave or holder.

--- a/pkg/systemstatsmonitor/net_collector.go
+++ b/pkg/systemstatsmonitor/net_collector.go
@@ -19,11 +19,11 @@ package systemstatsmonitor
 import (
 	"fmt"
 
-	ssmtypes "k8s.io/node-problem-detector/pkg/systemstatsmonitor/types"
-	"k8s.io/node-problem-detector/pkg/util/metrics"
-
 	"github.com/prometheus/procfs"
 	"k8s.io/klog/v2"
+
+	ssmtypes "k8s.io/node-problem-detector/pkg/systemstatsmonitor/types"
+	"k8s.io/node-problem-detector/pkg/util/metrics"
 )
 
 type newInt64MetricFn func(metricID metrics.MetricID, viewName string, description string, unit string, aggregation metrics.Aggregation, tagNames []string) (metrics.Int64MetricInterface, error)
@@ -205,7 +205,8 @@ func NewNetCollectorOrDie(netConfig *ssmtypes.NetStatsConfig, procPath string) *
 }
 
 func (nc *netCollector) mustRegisterMetric(metricID metrics.MetricID, description, unit string,
-	aggregation metrics.Aggregation, exporter func(stat procfs.NetDevLine) int64) {
+	aggregation metrics.Aggregation, exporter func(stat procfs.NetDevLine) int64,
+) {
 	metricConfig, ok := nc.config.MetricsConfigs[string(metricID)]
 	if !ok {
 		klog.Fatalf("Metric config `%q` not found", metricID)
@@ -265,7 +266,8 @@ func newIfaceStatRecorder(newInt64Metric newInt64MetricFn) *ifaceStatRecorder {
 }
 
 func (r *ifaceStatRecorder) Register(metricID metrics.MetricID, viewName string, description string,
-	unit string, aggregation metrics.Aggregation, tagNames []string, exporter func(procfs.NetDevLine) int64) error {
+	unit string, aggregation metrics.Aggregation, tagNames []string, exporter func(procfs.NetDevLine) int64,
+) error {
 	if _, ok := r.collectors[metricID]; ok {
 		// Check duplication
 		return fmt.Errorf("metric %q already registered", metricID)

--- a/pkg/systemstatsmonitor/net_collector_test.go
+++ b/pkg/systemstatsmonitor/net_collector_test.go
@@ -51,7 +51,7 @@ func testCollectAux(t *testing.T, name string, excludeInterfaceRegexp ssmtypes.N
 
 	// mkdir -C /tmp/proc-X/net
 	procNetDir := path.Join(procDir, "net")
-	if err := os.Mkdir(procNetDir, 0777); err != nil {
+	if err := os.Mkdir(procNetDir, 0o777); err != nil {
 		t.Fatalf("Failed to create directory %q: %v", procNetDir, err)
 	}
 

--- a/pkg/systemstatsmonitor/osfeature_collector.go
+++ b/pkg/systemstatsmonitor/osfeature_collector.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
+
 	ssmtypes "k8s.io/node-problem-detector/pkg/systemstatsmonitor/types"
 	"k8s.io/node-problem-detector/pkg/util/metrics"
 	"k8s.io/node-problem-detector/pkg/util/metrics/system"
@@ -61,7 +62,7 @@ func NewOsFeatureCollectorOrDie(osFeatureConfig *ssmtypes.OSFeatureStatsConfig, 
 // 2. UnifiedCgroupHierarchy based on systemd.unified_cgroup_hierarchy
 // 3. KernelModuleIntegrity based on the loadpin enabled and a module signed.
 func (ofc *osFeatureCollector) recordFeaturesFromCmdline(cmdlineArgs []system.CmdlineArg) {
-	var featuresMap = map[string]int64{
+	featuresMap := map[string]int64{
 		"KTD":                    0,
 		"UnifiedCgroupHierarchy": 0,
 		"ModuleSigned":           0,
@@ -118,7 +119,7 @@ func (ofc *osFeatureCollector) recordFeaturesFromModules(modules []system.Module
 		knownModules = []system.Module{}
 	}
 
-	var hasGPUSupport = 0
+	hasGPUSupport := 0
 	unknownModules := []string{}
 
 	// Collect UnknownModules and check GPUSupport
@@ -136,8 +137,10 @@ func (ofc *osFeatureCollector) recordFeaturesFromModules(modules []system.Module
 	}
 	// record the UnknownModules and GPUSupport
 	if len(unknownModules) > 0 {
-		ofc.osFeature.Record(map[string]string{featureLabel: "UnknownModules",
-			valueLabel: strings.Join(unknownModules, ",")}, 1)
+		ofc.osFeature.Record(map[string]string{
+			featureLabel: "UnknownModules",
+			valueLabel:   strings.Join(unknownModules, ","),
+		}, 1)
 	} else {
 		ofc.osFeature.Record(map[string]string{featureLabel: "UnknownModules"},
 			0)

--- a/pkg/systemstatsmonitor/system_stats_monitor.go
+++ b/pkg/systemstatsmonitor/system_stats_monitor.go
@@ -35,7 +35,8 @@ const SystemStatsMonitorName = "system-stats-monitor"
 func init() {
 	problemdaemon.Register(SystemStatsMonitorName, types.ProblemDaemonHandler{
 		CreateProblemDaemonOrDie: NewSystemStatsMonitorOrDie,
-		CmdOptionDescription:     "Set to config file paths."})
+		CmdOptionDescription:     "Set to config file paths.",
+	})
 }
 
 type systemStatsMonitor struct {

--- a/pkg/util/convert_test.go
+++ b/pkg/util/convert_test.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/node-problem-detector/pkg/types"
 )
 

--- a/pkg/util/metrics/helpers.go
+++ b/pkg/util/metrics/helpers.go
@@ -25,8 +25,10 @@ import (
 	"go.opencensus.io/tag"
 )
 
-var tagMap map[string]tag.Key
-var tagMapMutex sync.RWMutex
+var (
+	tagMap      map[string]tag.Key
+	tagMapMutex sync.RWMutex
+)
 
 func init() {
 	tagMapMutex.Lock()
@@ -105,7 +107,8 @@ func ParsePrometheusMetrics(metricsText string) ([]Float64MetricRepresentation, 
 // When strictLabelMatching is set to true, the founded metric labels are identical to the provided labels;
 // when strictLabelMatching is set to false, the founded metric labels are a superset of the provided labels.
 func GetFloat64Metric(metrics []Float64MetricRepresentation, name string, labels map[string]string,
-	strictLabelMatching bool) (Float64MetricRepresentation, error) {
+	strictLabelMatching bool,
+) (Float64MetricRepresentation, error) {
 	for _, metric := range metrics {
 		if metric.Name != name {
 			continue

--- a/pkg/util/metrics/system/cmdline_args.go
+++ b/pkg/util/metrics/system/cmdline_args.go
@@ -42,7 +42,7 @@ func splitAfterSpace(inputChar rune) bool {
 		withinQuotes = !withinQuotes
 		return false
 	}
-	//ignore spaces when it is within quotes.
+	// ignore spaces when it is within quotes.
 	if withinQuotes {
 		return false
 	}
@@ -59,7 +59,7 @@ func CmdlineArgs(cmdlineFilePath string) ([]CmdlineArg, error) {
 		return nil, fmt.Errorf("no lines are returned")
 	}
 	cmdlineArgs := strings.FieldsFunc(lines[0], splitAfterSpace)
-	var result = make([]CmdlineArg, 0, len(cmdlineArgs))
+	result := make([]CmdlineArg, 0, len(cmdlineArgs))
 	// for commandline only one line is returned.
 	for _, words := range cmdlineArgs {
 		// Ignore the keys that start with double quotes
@@ -68,14 +68,14 @@ func CmdlineArgs(cmdlineFilePath string) ([]CmdlineArg, error) {
 		}
 		tokens := strings.Split(words, "=")
 		if len(tokens) < 2 {
-			var stats = CmdlineArg{
+			stats := CmdlineArg{
 				Key: tokens[0],
 			}
 			result = append(result, stats)
 		} else {
-			//remove quotes in the values
+			// remove quotes in the values
 			trimmedValue := strings.Trim(tokens[1], "\"'")
-			var stats = CmdlineArg{
+			stats := CmdlineArg{
 				Key:   tokens[0],
 				Value: trimmedValue,
 			}

--- a/pkg/util/metrics/system/cmdline_args_test.go
+++ b/pkg/util/metrics/system/cmdline_args_test.go
@@ -91,5 +91,4 @@ func TestCmdlineStats_String(t *testing.T) {
 	e := `{"key":"test","value":"test"}`
 	assert.Equal(t,
 		e, fmt.Sprintf("%v", v), "CmdlineArg string is invalid: %v", v)
-
 }

--- a/pkg/util/metrics/system/module_stats.go
+++ b/pkg/util/metrics/system/module_stats.go
@@ -40,7 +40,7 @@ func Modules(modulesFilePath string) ([]Module, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading the contents of %s: %s", modulesFilePath, err)
 	}
-	var result = make([]Module, 0, len(lines))
+	result := make([]Module, 0, len(lines))
 
 	/* a line of /proc/modules has the following structure
 	  nf_nat 61440 2 xt_MASQUERADE,iptable_nat, Live 0x0000000000000000  (O)
@@ -55,14 +55,13 @@ func Modules(modulesFilePath string) ([]Module, error) {
 	*/
 	for _, line := range lines {
 		fields := strings.Fields(line)
-		moduleName := fields[0] // name of the module
-		numberOfInstances, err :=
-			strconv.ParseUint((fields[2]), 10, 64) // instances of the module are currently loaded
+		moduleName := fields[0]                                          // name of the module
+		numberOfInstances, err := strconv.ParseUint((fields[2]), 10, 64) // instances of the module are currently loaded
 		if err != nil {
 			numberOfInstances = 0
 		}
 
-		var module = Module{
+		module := Module{
 			ModuleName: moduleName,
 			Instances:  numberOfInstances,
 		}

--- a/pkg/util/metrics/system/module_stats_test.go
+++ b/pkg/util/metrics/system/module_stats_test.go
@@ -116,5 +116,4 @@ func TestModuleStat_String(t *testing.T) {
 	e := `{"moduleName":"test","instances":2,"proprietary":false,"outOfTree":false,"unsigned":false}`
 	assert.Equal(t,
 		e, fmt.Sprintf("%v", v), "Module string is invalid: %v", v)
-
 }


### PR DESCRIPTION
The `.golangci.yml` configuration was updated to enforce formatting.
This PR addresses multiple linting issues reported by `golangci-lint`.

The `golangci-lint run --fix` command was used to automatically correct problems related to import order (gci), code formatting (gofumpt), and other style violations across the codebase.
 
