### PR TITLE
[WIP] made cross compile instead of qemu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,21 @@
 # directly replaced. See here, and note that "stage" parameter mentioned there has been renamed to
 # "build-context": https://github.com/docker/buildx/pull/904#issuecomment-1005871838
 FROM golang:1.24.6-bookworm@sha256:bdc7cfd953b2701fcd95fd591ea3d788f41e4b74f21f1787b9f9843a28e72196 AS builder-base
-FROM builder-base AS builder
+FROM --platform=$BUILDPLATFORM builder-base AS builder
 
 ARG TARGETARCH
 
 ENV GOPATH=/gopath/
 ENV PATH=$GOPATH/bin:$PATH
 
-RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev gcc-aarch64-linux-gnu
+RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu
 RUN go version
 
 COPY . /gopath/src/k8s.io/node-problem-detector/
 WORKDIR /gopath/src/k8s.io/node-problem-detector
-RUN GOARCH=${TARGETARCH} make bin/node-problem-detector bin/health-checker bin/log-counter
+RUN GOARCH=${TARGETARCH} make bin/health-checker
+RUN GOARCH=${TARGETARCH} make bin/log-counter
+RUN GOARCH=${TARGETARCH} make bin/node-problem-detector
 
 FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.5@sha256:dd9c1f36c33b410480f6e6dcdfc075b0dfcab2c137953dd40189dbd06bdf9938 AS base
 


### PR DESCRIPTION
Gemini generated:

# The Problem

  The build was failing specifically when creating the arm64 version of the container image. The build log showed a segmentation fault from the C compiler
  (aarch64-linux-gnu-gcc).

  This happens because the build machine is an amd64 architecture, but it's being asked to build an image for arm64. To do this, Docker's build system (BuildKit)
  uses QEMU to emulate an arm64 environment. Running a compiler inside this emulated environment is often slow and can be unreliable, sometimes leading to crashes
  like the one we saw.

# The Solution: Native Cross-Compilation

  The standard and much more reliable solution is to use native cross-compilation. Instead of emulating the target architecture, we run the compiler on the native
  architecture of the build machine (amd64) and tell it to produce binaries for the target architecture (arm64). This is faster and avoids the instability of
  emulation.

  This is achieved with a multi-stage Dockerfile. The first stage (the builder) runs on the native build platform, compiles the code for all target platforms, and
  the final stage copies the compiled binaries into the target platform's image.

  Detailed Dockerfile Changes

   1. `FROM --platform=$BUILDPLATFORM builder-base AS builder`
       * Old: FROM builder-base AS builder
       * Change: I added the --platform=$BUILDPLATFORM flag.
       * Why: This is the key change. BUILDPLATFORM is an automatic variable provided by Docker's BuildKit that represents the architecture of the machine
         performing the build (e.g., linux/amd64). This flag forces the builder stage to always run natively on the build machine, completely avoiding QEMU
         emulation during the compilation step. The TARGETARCH variable (e.g., arm64) is still available inside this stage, so we can use it to tell our tools what
         architecture to build for.

   2. `RUN apt-get ... install ... gcc-x86-64-linux-gnu`
       * Old: ... install libsystemd-dev gcc-aarch64-linux-gnu
       * Change: I added gcc-x86-64-linux-gnu to the list of packages to install.
       * Why: The original file only installed the cross-compiler for arm64. Since the Makefile is also responsible for building the amd64 binary, I added the
         corresponding amd64 C compiler to ensure the toolchain is complete for both target architectures within our native amd64 builder.

  The rest of the Dockerfile and the Makefile already worked correctly with this setup, as the Makefile uses the GOARCH=${TARGETARCH} variable to select the
  appropriate C compiler (CC).