### PR TITLE
[WIP] Fix: Suppress dpkg warnings in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ ARG TARGETARCH
 ENV GOPATH=/gopath/
 ENV PATH=$GOPATH/bin:$PATH
 
+# Pre-create directories to avoid warnings from update-alternatives.
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7
 RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev gcc-aarch64-linux-gnu
 RUN go version
 
@@ -38,6 +40,8 @@ FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.5@sha256:dd9c1f36c33b
 
 LABEL maintainer="Random Liu <lantaol@google.com>"
 
+# Pre-create directories to avoid warnings from update-alternatives.
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7
 RUN clean-install util-linux bash libsystemd-dev
 
 # Avoid symlink of /etc/localtime.


### PR DESCRIPTION
  This change prevents dpkg from installing documentation files, which resolves several update-alternatives warnings that were occurring during  the Docker build process.

  The following warnings are fixed by this change:

 1. update-alternatives: error: alternative path /usr/share/man/man7/bash-builtins.7.gz doesn't exist
 2. update-alternatives: warning: forcing reinstallation of alternative /bin/more because link group pager is broken
 3. update-alternatives: warning: skip creation of /usr/share/man/man1/pager.1.gz because associated file /usr/share/man/man1/more.1.gz (of link group pager) doesn't exist

  This also has the minor benefit of slightly reducing the final image size.