### PR TITLE
fix the static ckeck linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,10 @@ linters:
   default: none
   enable:
     - ineffassign
+    - unused
+    - govet
+    #- errcheck
+    - staticcheck
   exclusions:
     generated: lax
     paths:

--- a/pkg/custompluginmonitor/types/config.go
+++ b/pkg/custompluginmonitor/types/config.go
@@ -161,7 +161,7 @@ func (cpc CustomPluginConfig) Validate() error {
 			}
 		}
 		if !defaultConditionExists {
-			return fmt.Errorf("Permanent problem %s does not have preset default condition.", conditionType)
+			return fmt.Errorf("permanent problem %s does not have preset default condition", conditionType)
 		}
 	}
 

--- a/pkg/exporters/k8sexporter/condition/manager.go
+++ b/pkg/exporters/k8sexporter/condition/manager.go
@@ -120,7 +120,7 @@ func (c *conditionManager) syncLoop(ctx context.Context) {
 				c.sync(ctx)
 			}
 		case <-ctx.Done():
-			break
+			return
 		}
 	}
 }

--- a/pkg/exporters/k8sexporter/condition/manager_test.go
+++ b/pkg/exporters/k8sexporter/condition/manager_test.go
@@ -83,8 +83,7 @@ func TestNeedUpdates(t *testing.T) {
 		t.Log(tc.name)
 		if tc.condition != "" {
 			// Guarantee that the time advances before creating a new condition.
-			for now := time.Now(); now == time.Now(); {
-			}
+			time.Sleep(time.Nanosecond)
 			c = newTestCondition(tc.condition)
 		}
 		m.UpdateCondition(c)

--- a/pkg/exporters/k8sexporter/problemclient/configs.go
+++ b/pkg/exporters/k8sexporter/problemclient/configs.go
@@ -89,7 +89,7 @@ func getKubeClientConfig(uri *url.URL) (*kube_rest.Config, error) {
 		kubeConfig.GroupVersion = &schema.GroupVersion{Version: APIVersion}
 		kubeConfig.Insecure = configOverrides.ClusterInfo.InsecureSkipTLSVerify
 		if configOverrides.ClusterInfo.InsecureSkipTLSVerify {
-			kubeConfig.TLSClientConfig.CAFile = ""
+			kubeConfig.CAFile = ""
 		}
 	} else {
 		authFile := ""

--- a/pkg/exporters/prometheusexporter/prometheus_exporter.go
+++ b/pkg/exporters/prometheusexporter/prometheus_exporter.go
@@ -56,5 +56,4 @@ func NewExporterOrDie(npdo *options.NodeProblemDetectorOptions) types.Exporter {
 // ExportProblems does nothing.
 // Prometheus exporter only exports metrics.
 func (pe *prometheusExporter) ExportProblems(status *types.Status) {
-	return
 }

--- a/pkg/exporters/stackdriver/gce/type.go
+++ b/pkg/exporters/stackdriver/gce/type.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gce
 
 import (
+	"context"
+
 	"cloud.google.com/go/compute/metadata"
 	"k8s.io/klog/v2"
 )
@@ -38,26 +40,28 @@ func (md *Metadata) HasMissingField() bool {
 func (md *Metadata) PopulateFromGCE() error {
 	var err error
 	klog.Info("Fetching GCE metadata from metadata server")
+	// Need to be initialized with a context at the main.
+	ctx := context.TODO()
 	if md.ProjectID == "" {
-		md.ProjectID, err = metadata.ProjectID()
+		md.ProjectID, err = metadata.ProjectIDWithContext(ctx)
 		if err != nil {
 			return err
 		}
 	}
 	if md.Zone == "" {
-		md.Zone, err = metadata.Zone()
+		md.Zone, err = metadata.ZoneWithContext(ctx)
 		if err != nil {
 			return err
 		}
 	}
 	if md.InstanceID == "" {
-		md.InstanceID, err = metadata.InstanceID()
+		md.InstanceID, err = metadata.InstanceIDWithContext(ctx)
 		if err != nil {
 			return err
 		}
 	}
 	if md.InstanceName == "" {
-		md.InstanceName, err = metadata.InstanceName()
+		md.InstanceName, err = metadata.InstanceNameWithContext(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/exporters/stackdriver/stackdriver_exporter.go
+++ b/pkg/exporters/stackdriver/stackdriver_exporter.go
@@ -186,7 +186,6 @@ func (se *stackdriverExporter) populateMetadataOrDie() {
 // ExportProblems does nothing.
 // Stackdriver exporter only exports metrics.
 func (se *stackdriverExporter) ExportProblems(status *types.Status) {
-	return
 }
 
 type commandLineOptions struct {

--- a/pkg/problemmetrics/problem_metrics.go
+++ b/pkg/problemmetrics/problem_metrics.go
@@ -78,7 +78,7 @@ func NewProblemMetricsManagerOrDie() *ProblemMetricsManager {
 // IncrementProblemCounter increments the value of a problem counter.
 func (pmm *ProblemMetricsManager) IncrementProblemCounter(reason string, count int64) error {
 	if pmm.problemCounter == nil {
-		return errors.New("problem counter is being incremented before initialized.")
+		return errors.New("problem counter is being incremented before initialized")
 	}
 
 	return pmm.problemCounter.Record(map[string]string{"reason": reason}, count)
@@ -87,7 +87,7 @@ func (pmm *ProblemMetricsManager) IncrementProblemCounter(reason string, count i
 // SetProblemGauge sets the value of a problem gauge.
 func (pmm *ProblemMetricsManager) SetProblemGauge(problemType string, reason string, value bool) error {
 	if pmm.problemGauge == nil {
-		return errors.New("problem gauge is being set before initialized.")
+		return errors.New("problem gauge is being set before initialized")
 	}
 
 	pmm.problemTypeToReasonMutex.Lock()

--- a/pkg/systemlogmonitor/config.go
+++ b/pkg/systemlogmonitor/config.go
@@ -54,8 +54,8 @@ func (mc *MonitorConfig) ApplyDefaultConfiguration() {
 	if mc.EnableMetricsReporting == nil {
 		mc.EnableMetricsReporting = &defaultEnableMetricsReporting
 	}
-	if mc.WatcherConfig.Lookback == "" {
-		mc.WatcherConfig.Lookback = defaultLookback
+	if mc.Lookback == "" {
+		mc.Lookback = defaultLookback
 	}
 }
 

--- a/pkg/systemlogmonitor/log_buffer.go
+++ b/pkg/systemlogmonitor/log_buffer.go
@@ -47,8 +47,8 @@ type logBuffer struct {
 // lines of patterns we support.
 func NewLogBuffer(maxLines int) *logBuffer {
 	return &logBuffer{
-		buffer: make([]*types.Log, maxLines, maxLines),
-		msg:    make([]string, maxLines, maxLines),
+		buffer: make([]*types.Log, maxLines),
+		msg:    make([]string, maxLines),
 		max:    maxLines,
 	}
 }

--- a/pkg/systemlogmonitor/log_monitor_test.go
+++ b/pkg/systemlogmonitor/log_monitor_test.go
@@ -25,7 +25,6 @@ import (
 
 	"k8s.io/node-problem-detector/pkg/problemdaemon"
 	"k8s.io/node-problem-detector/pkg/problemmetrics"
-	logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
 	systemlogtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
 	"k8s.io/node-problem-detector/pkg/types"
 	"k8s.io/node-problem-detector/pkg/util"
@@ -58,7 +57,7 @@ func TestGenerateStatusForConditions(t *testing.T) {
 			Transition: time.Unix(500, 500),
 		},
 	}
-	logs := []*logtypes.Log{
+	logs := []*systemlogtypes.Log{
 		{
 			Timestamp: time.Unix(1000, 1000),
 			Message:   "test message 1",
@@ -69,12 +68,12 @@ func TestGenerateStatusForConditions(t *testing.T) {
 		},
 	}
 	for c, test := range []struct {
-		rule     logtypes.Rule
+		rule     systemlogtypes.Rule
 		expected types.Status
 	}{
 		// Do not need Pattern because we don't do pattern match in this test
 		{
-			rule: logtypes.Rule{
+			rule: systemlogtypes.Rule{
 				Type:      types.Perm,
 				Condition: testConditionA,
 				Reason:    "test reason",
@@ -102,7 +101,7 @@ func TestGenerateStatusForConditions(t *testing.T) {
 		},
 		// Should not update transition time when status and reason are not changed.
 		{
-			rule: logtypes.Rule{
+			rule: systemlogtypes.Rule{
 				Type:      types.Perm,
 				Condition: testConditionA,
 				Reason:    "initial reason",
@@ -121,7 +120,7 @@ func TestGenerateStatusForConditions(t *testing.T) {
 			},
 		},
 		{
-			rule: logtypes.Rule{
+			rule: systemlogtypes.Rule{
 				Type:   types.Temp,
 				Reason: "test reason",
 			},
@@ -157,19 +156,19 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 	testCases := []struct {
 		name            string
 		conditions      []types.Condition
-		triggeredRules  []logtypes.Rule
+		triggeredRules  []systemlogtypes.Rule
 		expectedMetrics []metrics.Int64MetricRepresentation
 	}{
 		{
 			name:            "one temporary problem that has not happened",
 			conditions:      []types.Condition{},
-			triggeredRules:  []logtypes.Rule{},
+			triggeredRules:  []systemlogtypes.Rule{},
 			expectedMetrics: []metrics.Int64MetricRepresentation{},
 		},
 		{
 			name:       "one temporary problem happened once",
 			conditions: []types.Condition{},
-			triggeredRules: []logtypes.Rule{
+			triggeredRules: []systemlogtypes.Rule{
 				{
 					Type:   types.Temp,
 					Reason: "problem reason foo",
@@ -186,7 +185,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 		{
 			name:       "one temporary problem happened twice",
 			conditions: []types.Condition{},
-			triggeredRules: []logtypes.Rule{
+			triggeredRules: []systemlogtypes.Rule{
 				{
 					Type:   types.Temp,
 					Reason: "problem reason foo",
@@ -207,7 +206,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 		{
 			name:       "two different temporary problems happened",
 			conditions: []types.Condition{},
-			triggeredRules: []logtypes.Rule{
+			triggeredRules: []systemlogtypes.Rule{
 				{
 					Type:   types.Temp,
 					Reason: "problem reason foo",
@@ -238,7 +237,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 					Status: types.False,
 				},
 			},
-			triggeredRules: []logtypes.Rule{
+			triggeredRules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -266,7 +265,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 					Status: types.False,
 				},
 			},
-			triggeredRules: []logtypes.Rule{
+			triggeredRules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -299,7 +298,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 					Status: types.False,
 				},
 			},
-			triggeredRules: []logtypes.Rule{
+			triggeredRules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -346,7 +345,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 					Status: types.False,
 				},
 			},
-			triggeredRules: []logtypes.Rule{
+			triggeredRules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -397,7 +396,7 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 			problemmetrics.GlobalProblemMetricsManager = fakePMM
 
 			for _, rule := range test.triggeredRules {
-				l.generateStatus([]*logtypes.Log{{}}, rule)
+				l.generateStatus([]*systemlogtypes.Log{{}}, rule)
 			}
 
 			gotMetrics := append(fakeProblemCounter.ListMetrics(), fakeProblemGauge.ListMetrics()...)
@@ -411,17 +410,17 @@ func TestGenerateStatusForMetrics(t *testing.T) {
 func TestInitializeProblemMetricsOrDie(t *testing.T) {
 	testCases := []struct {
 		name            string
-		rules           []logtypes.Rule
+		rules           []systemlogtypes.Rule
 		expectedMetrics []metrics.Int64MetricRepresentation
 	}{
 		{
 			name:            "no problem type at all",
-			rules:           []logtypes.Rule{},
+			rules:           []systemlogtypes.Rule{},
 			expectedMetrics: []metrics.Int64MetricRepresentation{},
 		},
 		{
 			name: "one type of temporary problem",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:   types.Temp,
 					Reason: "problem reason foo",
@@ -437,7 +436,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 		},
 		{
 			name: "one type of permanent problem",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -459,7 +458,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 		},
 		{
 			name: "duplicate temporary problem types",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:   types.Temp,
 					Reason: "problem reason foo",
@@ -479,7 +478,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 		},
 		{
 			name: "multiple temporary problem types",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:   types.Temp,
 					Reason: "problem reason foo",
@@ -504,7 +503,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 		},
 		{
 			name: "multiple permanent problem types with same condition",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -541,7 +540,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 		},
 		{
 			name: "multiple permanent problem types with different conditions",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -578,7 +577,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 		},
 		{
 			name: "duplicate permanent problem types",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:      types.Perm,
 					Condition: "ConditionA",
@@ -605,7 +604,7 @@ func TestInitializeProblemMetricsOrDie(t *testing.T) {
 		},
 		{
 			name: "mixture of temporary and permanent problem types",
-			rules: []logtypes.Rule{
+			rules: []systemlogtypes.Rule{
 				{
 					Type:   types.Temp,
 					Reason: "problem reason foo",

--- a/pkg/util/helpers_linux.go
+++ b/pkg/util/helpers_linux.go
@@ -73,7 +73,7 @@ func getOSVersion(osReleasePath string) (string, error) {
 	case "flatcar":
 		return getDebianVersion(osReleaseMap), nil
 	default:
-		return "", fmt.Errorf("Unsupported ID in /etc/os-release: %q", osReleaseMap["ID"])
+		return "", fmt.Errorf("unsupported ID in /etc/os-release: %q", osReleaseMap["ID"])
 	}
 }
 

--- a/pkg/util/metrics/helpers.go
+++ b/pkg/util/metrics/helpers.go
@@ -87,11 +87,12 @@ func ParsePrometheusMetrics(metricsText string) ([]Float64MetricRepresentation, 
 			}
 
 			var value float64
-			if *metricFamily.Type == pcm.MetricType_COUNTER {
+			switch *metricFamily.Type {
+			case pcm.MetricType_COUNTER:
 				value = *metric.Counter.Value
-			} else if *metricFamily.Type == pcm.MetricType_GAUGE {
+			case pcm.MetricType_GAUGE:
 				value = *metric.Gauge.Value
-			} else {
+			default:
 				return metrics, fmt.Errorf("unexpected MetricType %s for metric %s",
 					pcm.MetricType_name[int32(*metricFamily.Type)], *metricFamily.Name)
 			}


### PR DESCRIPTION
Tried fixing most of them with AI. Ended up cleaning up after it a lot. Anyways, a few improvements here:

```
./.bin/golangci-lint run --config .golangci.yml ./...
pkg/custompluginmonitor/types/config.go:164:11: ST1005: error strings should not end with punctuation or newlines (staticcheck)
                        return fmt.Errorf("Permanent problem %s does not have preset default condition.", conditionType)
                               ^
pkg/exporters/k8sexporter/condition/manager.go:123:4: SA4011: ineffective break statement. Did you mean to break out of the outer loop? (staticcheck)
                        break
                        ^
pkg/exporters/k8sexporter/condition/manager_test.go:86:27: QF1009: probably want to use time.Time.Equal instead (staticcheck)
                        for now := time.Now(); now == time.Now(); {
                                               ^
pkg/exporters/k8sexporter/problemclient/configs.go:92:15: QF1008: could remove embedded field "TLSClientConfig" from selector (staticcheck)
                        kubeConfig.TLSClientConfig.CAFile = ""
                                   ^
pkg/exporters/prometheusexporter/prometheus_exporter.go:59:2: S1023: redundant return statement (staticcheck)
        return
        ^
pkg/exporters/stackdriver/gce/type.go:42:23: SA1019: metadata.ProjectID is deprecated: Please use the context aware variant [ProjectIDWithContext]. (staticcheck)
                md.ProjectID, err = metadata.ProjectID()
                                    ^
pkg/exporters/stackdriver/gce/type.go:48:18: SA1019: metadata.Zone is deprecated: Please use the context aware variant [ZoneWithContext]. (staticcheck)
                md.Zone, err = metadata.Zone()
                               ^
pkg/exporters/stackdriver/gce/type.go:54:24: SA1019: metadata.InstanceID is deprecated: Please use the context aware variant [InstanceIDWithContext]. (staticcheck)
                md.InstanceID, err = metadata.InstanceID()
                                     ^
pkg/exporters/stackdriver/gce/type.go:60:26: SA1019: metadata.InstanceName is deprecated: Please use the context aware variant [InstanceNameWithContext]. (staticcheck)
                md.InstanceName, err = metadata.InstanceName()
                                       ^
pkg/exporters/stackdriver/stackdriver_exporter.go:189:2: S1023: redundant return statement (staticcheck)
        return
        ^
pkg/problemmetrics/problem_metrics.go:81:10: ST1005: error strings should not end with punctuation or newlines (staticcheck)
                return errors.New("problem counter is being incremented before initialized.")
                       ^
pkg/problemmetrics/problem_metrics.go:90:10: ST1005: error strings should not end with punctuation or newlines (staticcheck)
                return errors.New("problem gauge is being set before initialized.")
                       ^
pkg/systemlogmonitor/config.go:57:8: QF1008: could remove embedded field "WatcherConfig" from selector (staticcheck)
        if mc.WatcherConfig.Lookback == "" {
              ^
pkg/systemlogmonitor/config.go:58:6: QF1008: could remove embedded field "WatcherConfig" from selector (staticcheck)
                mc.WatcherConfig.Lookback = defaultLookback
                   ^
pkg/systemlogmonitor/log_buffer.go:50:30: S1019: should use make([]*types.Log, maxLines) instead (staticcheck)
                buffer: make([]*types.Log, maxLines, maxLines),
                                           ^
pkg/systemlogmonitor/log_buffer.go:51:26: S1019: should use make([]string, maxLines) instead (staticcheck)
                msg:    make([]string, maxLines, maxLines),
                                       ^
pkg/systemlogmonitor/log_monitor_test.go:28:2: ST1019: package "k8s.io/node-problem-detector/pkg/systemlogmonitor/types" is being imported more than once (staticcheck)
        logtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
        ^
pkg/systemlogmonitor/log_monitor_test.go:29:2: ST1019(related information): other import of "k8s.io/node-problem-detector/pkg/systemlogmonitor/types" (staticcheck)
        systemlogtypes "k8s.io/node-problem-detector/pkg/systemlogmonitor/types"
        ^
pkg/util/helpers_linux.go:76:14: ST1005: error strings should not be capitalized (staticcheck)
                return "", fmt.Errorf("Unsupported ID in /etc/os-release: %q", osReleaseMap["ID"])
                           ^
pkg/util/metrics/helpers.go:90:4: QF1003: could use tagged switch on *metricFamily.Type (staticcheck)
                        if *metricFamily.Type == pcm.MetricType_COUNTER {
                        ^
20 issues:
* staticcheck: 20
make: *** [Makefile:120: lint] Error 1

```