### PR TITLE
Update Cloud Build config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_PLATFORMS=linux/amd64,linux/arm64
 PLATFORMS=$(LINUX_PLATFORMS) windows_amd64
 
 # VERSION is the version of the binary.
-VERSION?=$(shell if [ -d .git ]; then echo `git describe --tags --dirty`; else echo "UNKNOWN"; fi)
+VERSION?=$(shell git describe --tags --always --dirty)
 
 # TAG is the tag of the container image, default to binary version.
 TAG?=$(VERSION)
@@ -275,10 +275,6 @@ build-in-docker: clean docker-builder
 		-c 'cd /gopath/src/k8s.io/node-problem-detector/ && make build-binaries'
 
 push-container: build-container
-	# So we can push to docker hub by setting REGISTRY
-ifneq (,$(findstring gcr.io,$(REGISTRY)))
-	gcloud auth configure-docker
-endif
 	# Build should be cached from build-container
 	docker buildx build --push --platform $(DOCKER_PLATFORMS) -t $(IMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,22 +5,12 @@ timeout: 3600s
 options:
   # job builds a multi-arch docker image for amd64 and arm64
   machineType: E2_HIGHCPU_8
+  substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230623-56e06d7c18'
-    entrypoint: bash
-    env:
-    - PROW_GIT_TAG=$_GIT_TAG
-    - PULL_BASE_REF=$_PULL_BASE_REF
-    - VERSION=$_PULL_BASE_REF
-    - DOCKER_CLI_EXPERIMENTAL=enabled
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: make
     args:
-    - -c
-    - |
-      echo "Building/Pushing NPD containers"
-      apk add musl-dev gcc
-      make push-container
+    - push-container
 substitutions:
-  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
-  # can be used as a substitution
-  _GIT_TAG: 'PLACE_HOLDER'
-  _PULL_BASE_REF: 'master'
+  _GIT_TAG: 'dev'
+  _PULL_BASE_REF: 'dev'


### PR DESCRIPTION
This should allow us to use the images that are built by `node-problem-detector-push-images` and pushed to `gcr.io/k8s-staging-npd`.
This requires #1122 and https://github.com/kubernetes/test-infra/pull/35512.

/cc @SergeyKanzhelev @wangzhen127 @ameukam 