### PR TITLE
Automated cherry pick of #1121: Add hakman as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,5 +11,5 @@ approvers:
   - wangzhen127
   - xueweiz
   - hakman
-  emeritus_approvers:  
+emeritus_approvers:  
   - vteratipally


### PR DESCRIPTION
Cherry pick of #1121 on release-0.8.

#1121: Add hakman as an approver

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```