### PR TITLE
Update log pattern to match kubelet service name from kubelet .deb package

### DIFF
--- a/config/systemd-monitor-counter.json
+++ b/config/systemd-monitor-counter.json
@@ -37,8 +37,8 @@
         "--lookback=20m",
         "--delay=5m",
         "--count=5",
-        "--pattern=Started (Kubernetes kubelet|kubelet.service|kubelet.service - Kubernetes kubelet).",
-        "--revert-pattern=Stopping (Kubernetes kubelet|kubelet.service|kubelet.service - Kubernetes kubelet)..."
+        "--pattern=Started (Kubernetes kubelet|kubelet.service|kubelet.service - .*).",
+        "--revert-pattern=Stopping (Kubernetes kubelet|kubelet.service|kubelet.service - .*)..."
       ],
       "timeout": "1m"
     },

--- a/config/systemd-monitor.json
+++ b/config/systemd-monitor.json
@@ -13,7 +13,7 @@
 		{
 			"type": "temporary",
 			"reason": "KubeletStart",
-			"pattern": "Started (Kubernetes kubelet|kubelet.service|kubelet.service - Kubernetes kubelet)."
+			"pattern": "Started (Kubernetes kubelet|kubelet.service|kubelet.service - Kubernetes kubelet|kubelet.service - .*)."
 		},
 		{
 			"type": "temporary",

--- a/deployment/node-problem-detector-config.yaml
+++ b/deployment/node-problem-detector-config.yaml
@@ -46,9 +46,9 @@ data:
                 "pattern": "divide error: 0000 \\[#\\d+\\] SMP"
             },
             {
-    			"type": "temporary",
-    			"reason": "MemoryReadError",
-    			"pattern": "CE memory read error .*"
+                "type": "temporary",
+                "reason": "MemoryReadError",
+                "pattern": "CE memory read error .*"
             },
             {
                 "type": "permanent",


### PR DESCRIPTION
This makes the log pattern match the kubelet service name from https://github.com/kubernetes/release/blob/master/cmd/krel/templates/latest/kubelet/kubelet.service which is what's installed by the kubelet .deb package (and presumably the rpm as well).

This also matches the example show in the docs here: https://kubernetes.io/docs/reference/node/systemd-watchdog/

Fixes #1129 