### PR TITLE
Automated cherry pick of #1122: Use cross-compile for Docker builds
#1123: Update Cloud Build config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,14 @@
 # directly replaced. See here, and note that "stage" parameter mentioned there has been renamed to
 # "build-context": https://github.com/docker/buildx/pull/904#issuecomment-1005871838
 FROM golang:1.24.6-bookworm@sha256:bdc7cfd953b2701fcd95fd591ea3d788f41e4b74f21f1787b9f9843a28e72196 AS builder-base
-FROM builder-base AS builder
+FROM --platform=$BUILDPLATFORM builder-base AS builder
 
 ARG TARGETARCH
 
 ENV GOPATH=/gopath/
 ENV PATH=$GOPATH/bin:$PATH
 
-RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev gcc-aarch64-linux-gnu
+RUN apt-get update --fix-missing && apt-get --yes install libsystemd-dev
 RUN go version
 
 COPY . /gopath/src/k8s.io/node-problem-detector/

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_PLATFORMS=linux/amd64,linux/arm64
 PLATFORMS=$(LINUX_PLATFORMS) windows_amd64
 
 # VERSION is the version of the binary.
-VERSION?=$(shell if [ -d .git ]; then echo `git describe --tags --dirty`; else echo "UNKNOWN"; fi)
+VERSION?=$(shell git describe --tags --always --dirty)
 
 # TAG is the tag of the container image, default to binary version.
 TAG?=$(VERSION)
@@ -275,10 +275,6 @@ build-in-docker: clean docker-builder
 		-c 'cd /gopath/src/k8s.io/node-problem-detector/ && make build-binaries'
 
 push-container: build-container
-	# So we can push to docker hub by setting REGISTRY
-ifneq (,$(findstring gcr.io,$(REGISTRY)))
-	gcloud auth configure-docker
-endif
 	# Build should be cached from build-container
 	docker buildx build --push --platform $(DOCKER_PLATFORMS) -t $(IMAGE) --build-arg LOGCOUNTER=$(LOGCOUNTER) .
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,22 +5,12 @@ timeout: 3600s
 options:
   # job builds a multi-arch docker image for amd64 and arm64
   machineType: E2_HIGHCPU_8
+  substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20230623-56e06d7c18'
-    entrypoint: bash
-    env:
-    - PROW_GIT_TAG=$_GIT_TAG
-    - PULL_BASE_REF=$_PULL_BASE_REF
-    - VERSION=$_PULL_BASE_REF
-    - DOCKER_CLI_EXPERIMENTAL=enabled
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: make
     args:
-    - -c
-    - |
-      echo "Building/Pushing NPD containers"
-      apk add musl-dev gcc
-      make push-container
+    - push-container
 substitutions:
-  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
-  # can be used as a substitution
-  _GIT_TAG: 'PLACE_HOLDER'
-  _PULL_BASE_REF: 'master'
+  _GIT_TAG: 'dev'
+  _PULL_BASE_REF: 'dev'


### PR DESCRIPTION
Cherry pick of #1122 #1123 on release-0.8.

#1122: Use cross-compile for Docker builds
#1123: Update Cloud Build config

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```