### PR TITLE
Automated cherry pick of #1109: Enable tagging of release branches

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'release-*'
     paths:
       - version.txt
 
@@ -21,7 +22,6 @@ jobs:
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
-
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0


### PR DESCRIPTION
Cherry pick of #1109 on release-0.8.

#1109: Enable tagging of release branches

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```