### PR TITLE
Automated cherry pick of #1184: Update Go to 1.24.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 # Must override builder-base, not builder, since the latter is referred to later in the file and so must not be
 # directly replaced. See here, and note that "stage" parameter mentioned there has been renamed to
 # "build-context": https://github.com/docker/buildx/pull/904#issuecomment-1005871838
-FROM golang:1.24.10-bookworm@sha256:1a974b530d7a37a35bfc16e7581ab963075a06432e51af29642a178695f2371a AS builder-base
+FROM golang:1.24.11-bookworm@sha256:07a0d01bb30782aa8a2d2a2cdc03ea677a0546a5bf35211bb7191829b7c44f59 AS builder-base
 FROM --platform=$BUILDPLATFORM builder-base AS builder
 
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/node-problem-detector
 
-go 1.24.10
+go 1.24.11
 
 require (
 	cloud.google.com/go/compute/metadata v0.8.0

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/node-problem-detector/test
 
-go 1.24.10
+go 1.24.11
 
 replace k8s.io/node-problem-detector => ../.
 


### PR DESCRIPTION
Cherry pick of #1184 on release-1.34.

#1184: Update Go to 1.24.11

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```