### PR TITLE
add future time filter for log watchers when time across the year

### DIFF
--- a/pkg/systemlogmonitor/logwatchers/filelog/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/filelog/log_watcher.go
@@ -131,6 +131,13 @@ func (s *filelogWatcher) watchLoop() {
 			klog.V(5).Infof("Throwing away msg %q before start time: %v < %v", log.Message, log.Timestamp, s.startTime)
 			continue
 		}
+
+		// Discard messages after now, lots of log files are not record year. 1 min cover log write latency
+		if log.Timestamp.After(time.Now().Add(time.Minute)) {
+			klog.V(5).Infof("Throwing away msg %q after current time: %v < %v", log.Message, log.Timestamp, time.Now())
+			continue
+		}
+
 		s.logCh <- log
 	}
 }

--- a/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
+++ b/pkg/systemlogmonitor/logwatchers/journald/log_watcher.go
@@ -130,6 +130,12 @@ func (j *journaldWatcher) watchLoop() {
 			continue
 		}
 
+		// Discard messages after now, the journal log is not record year. 1 min cover log write latency
+		if entry.RealtimeTimestamp > timeToJournalTimestamp(time.Now().Add(time.Minute)) {
+			klog.V(5).Infof("Throwing away msg %q after current time: %v < %v", entry.Fields[sdjournal.SD_JOURNAL_FIELD_MESSAGE], entry.RealtimeTimestamp, time.Now())
+			continue
+		}
+
 		j.logCh <- translate(entry)
 	}
 }

--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
@@ -115,6 +115,12 @@ func (k *kernelLogWatcher) watchLoop() {
 				continue
 			}
 
+			// Discard messages after now, lots of log files are not record year. 1 min cover log write latency
+			if msg.Timestamp.After(time.Now().Add(time.Minute)) {
+				klog.V(5).Infof("Throwing away msg %q after current time: %v < %v", msg.Message, msg.Timestamp, time.Now())
+				continue
+			}
+
 			k.logCh <- &logtypes.Log{
 				Message:   strings.TrimSpace(msg.Message),
 				Timestamp: msg.Timestamp,


### PR DESCRIPTION
This pr is to fix this specail case:
1. kernel log file: 
```
root@:~# tail -n 1 /var/log/messages
Jan  6 02:06:53 kubelet[8137]: E0106 02:06:53.560506    8137 summary_sys_containers.go:89] "Failed to get system container stats" err="failed to get cgroup stats for \"/systemd/system.slice\": failed to get container info for \"/systemd/system.slice\": unknown container \"/systemd/system.slice\"" containerName="/systemd/system.slice"
```
2. journal log:
```
root@:~# journalctl -u kubelet -n 1
Jan 06 02:07:53 kubelet[8137]: E0106 02:07:53.698973    8137 summary_sys_containers.go:89] "Failed to get system container stats" err="failed to get cgroup stats for \"/systemd/system.slice\": failed to get co>
```
These logs are not record "year" of time, so when the time from 2025 to 2026, the NPD will think that the log in 2025-12-31 is after than 2026-01-01, so the logs from 2025 will be captured into 2026.