### PR TITLE
chore(readme): update chart install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,7 @@ to another registry.
 The easiest way to install node-problem-detector into your cluster is to use the [Helm](https://helm.sh/) [chart](https://github.com/deliveryhero/helm-charts/tree/master/stable/node-problem-detector):
 
 ```
-helm repo add deliveryhero https://charts.deliveryhero.io/
-helm install --generate-name deliveryhero/node-problem-detector
+helm install --generate-name oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector
 ```
 
 Alternatively, to install node-problem-detector manually:


### PR DESCRIPTION
The chart registry moved to github package registry according to the chart readme, this PR updates setup instructions on this repository as well to use `oci://ghcr.io/deliveryhero/helm-charts/node-problem-detector`

Ref: https://github.com/deliveryhero/helm-charts/tree/master/stable/node-problem-detector