### PR TITLE
fix(logwatchers/kmsg): don't close parser from Stop()

### DIFF
--- a/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
+++ b/pkg/systemlogmonitor/logwatchers/kmsg/log_watcher_linux.go
@@ -80,11 +80,8 @@ func (k *kernelLogWatcher) Watch() (<-chan *logtypes.Log, error) {
 	return k.logCh, nil
 }
 
-// Stop closes the kmsgparser
+// Stop signals the watch loop to stop.
 func (k *kernelLogWatcher) Stop() {
-	if err := k.kmsgParser.Close(); err != nil {
-		klog.Errorf("Failed to close kmsg parser: %v", err)
-	}
 	k.tomb.Stop()
 }
 


### PR DESCRIPTION
Closing the parser in Stop() triggers kmsgparser's read goroutine to close its output channel, which made watchLoop take the restart path (added in #1192) during intentional shutdown. Leave parser cleanup to watchLoop's defer, which is the single owner of the parser lifecycle.

/cc @ameukam @wangzhen127 @SergeyKanzhelev 