### PR TITLE
custom-plugin-monitor: Honor default condition status

### DIFF
--- a/pkg/custompluginmonitor/custom_plugin_monitor.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor.go
@@ -317,7 +317,15 @@ func initialConditions(defaults []types.Condition) []types.Condition {
 	conditions := make([]types.Condition, len(defaults))
 	copy(conditions, defaults)
 	for i := range conditions {
-		conditions[i].Status = types.False
+		switch conditions[i].Status {
+		case types.True, types.False, types.Unknown:
+		case "":
+			conditions[i].Status = types.False
+		default:
+			klog.Warningf("Condition %q has invalid initial status %q, defaulting to %q",
+				conditions[i].Type, conditions[i].Status, types.False)
+			conditions[i].Status = types.False
+		}
 		conditions[i].Transition = time.Now()
 	}
 	return conditions

--- a/pkg/custompluginmonitor/custom_plugin_monitor_test.go
+++ b/pkg/custompluginmonitor/custom_plugin_monitor_test.go
@@ -22,10 +22,32 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/node-problem-detector/pkg/problemdaemon"
+	"k8s.io/node-problem-detector/pkg/types"
 )
 
 func TestRegistration(t *testing.T) {
 	assert.NotPanics(t,
 		func() { problemdaemon.GetProblemDaemonHandlerOrDie("custom-plugin-monitor") },
 		"Custom plugin monitor failed to register itself as a problem daemon.")
+}
+
+func TestInitialConditions(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputStatus    types.ConditionStatus
+		expectedStatus types.ConditionStatus
+	}{
+		{name: "TestTrue", inputStatus: types.True, expectedStatus: types.True},
+		{name: "TestFalse", inputStatus: types.False, expectedStatus: types.False},
+		{name: "TestUnknown", inputStatus: types.Unknown, expectedStatus: types.Unknown},
+		{name: "TestUnset", inputStatus: "", expectedStatus: types.False},
+		{name: "TestInvalid", inputStatus: "garbage", expectedStatus: types.False},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defaults := []types.Condition{{Type: "TestCondition", Status: tt.inputStatus}}
+			conditions := initialConditions(defaults)
+			assert.Equal(t, tt.expectedStatus, conditions[0].Status)
+		})
+	}
 }


### PR DESCRIPTION
Users can define a default status, but that's being stomped on currently. Let's honor what's defined, if defined correctly... otherwise continue to default to False and log a warning.