### PR TITLE
fix: handle SIGTERM gracefully on unix

### DIFF
--- a/cmd/nodeproblemdetector/node_problem_detector_unix.go
+++ b/cmd/nodeproblemdetector/node_problem_detector_unix.go
@@ -21,6 +21,9 @@ package main
 import (
 	"context"
 	"flag"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -54,7 +57,9 @@ func main() {
 	}
 
 	pflag.Parse()
-	if err := npdMain(context.Background(), npdo); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := npdMain(ctx, npdo); err != nil {
 		klog.Fatalf("Problem detector failed with error: %v", err)
 	}
 }


### PR DESCRIPTION
We weren't catching SIGTERM and cancelling our context, so the go runtime would have us exit with a non-zero code when the signal was received. Let's catch it and try to exit gracefully.

i.e. before:

    (...)
    I0508 11:08:00.426917 1787442 log_monitor.go:237] Initialize condition generated: []
    ^C
    $ echo $?
    130

and now:

    (...)
    I0508 11:07:42.150562 1787146 log_monitor.go:237] Initialize condition generated: []
    ^C
    I0508 11:07:43.372093 1787146 log_monitor.go:123] Stop log monitor /tmp/npd-test.json
    I0508 11:07:43.652876 1787146 log_watcher.go:104] Stop watching filelog
    I0508 11:07:43.652923 1787146 log_monitor.go:144] Log monitor stopped: /tmp/npd-test.json
    $ echo $?
    0