### PR TITLE
test/e2e: inject synthetic ext4 kmsg lines instead of a real fault

### DIFF
--- a/test/e2e/metriconly/metrics_test.go
+++ b/test/e2e/metriconly/metrics_test.go
@@ -125,12 +125,10 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 		ginkgo.BeforeEach(func() {
 			err := npd.WaitForNPD(instance, []string{"problem_gauge"}, 120)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Expect NPD to become ready in 120s, but hit error: %v", err))
-			// This will trigger a ext4 error on the boot disk, causing the boot disk mounted as read-only and systemd-journald crashing.
 			instance.RunCommandOrFail("sudo /home/kubernetes/bin/problem-maker --problem Ext4FilesystemError")
 		})
 
 		ginkgo.It("NPD should update problem_counter{reason:Ext4Error} and problem_gauge{type:ReadonlyFilesystem}", func() {
-			ginkgo.Skip("Writing to /sys/fs/ext4/sda1/trigger_fs_error breaks SSH: https://github.com/kubernetes/node-problem-detector/issues/970")
 			time.Sleep(5 * time.Second)
 			assertMetricValueAtLeast(instance,
 				"problem_counter", map[string]string{"reason": "Ext4Error"},
@@ -138,13 +136,6 @@ var _ = ginkgo.Describe("NPD should export Prometheus metrics.", func() {
 			assertMetricValueInBound(instance,
 				"problem_gauge", map[string]string{"reason": "FilesystemIsReadOnly", "type": "ReadonlyFilesystem"},
 				1.0, 1.0)
-		})
-
-		ginkgo.It("NPD should remain healthy", func() {
-			ginkgo.Skip("Writing to /sys/fs/ext4/sda1/trigger_fs_error breaks SSH: https://github.com/kubernetes/node-problem-detector/issues/970")
-			npdStates := instance.RunCommandOrFail("sudo systemctl show node-problem-detector -p ActiveState -p SubState")
-			Expect(npdStates.Stdout).To(ContainSubstring("ActiveState=active"), "NPD is no longer active: %v", npdStates)
-			Expect(npdStates.Stdout).To(ContainSubstring("SubState=running"), "NPD is no longer running: %v", npdStates)
 		})
 	})
 

--- a/test/e2e/problemmaker/makers/filesystem.go
+++ b/test/e2e/problemmaker/makers/filesystem.go
@@ -16,22 +16,13 @@ limitations under the License.
 
 package makers
 
-import (
-	"os"
-
-	"k8s.io/klog/v2"
-)
+const ext4ErrorPattern = `EXT4-fs error (device sda1): fake filesystem error from problem-maker
+EXT4-fs (sda1): Remounting filesystem read-only`
 
 func init() {
 	ProblemGenerators["Ext4FilesystemError"] = makeFilesystemError
 }
 
-const ext4ErrorTrigger = "/sys/fs/ext4/sda1/trigger_fs_error"
-
 func makeFilesystemError() {
-	msg := []byte("fake filesystem error from problem-maker")
-	err := os.WriteFile(ext4ErrorTrigger, msg, 0200)
-	if err != nil {
-		klog.Fatalf("Failed writing log to %q: %v", ext4ErrorTrigger, err)
-	}
+	writeKernelMessageOrDie(ext4ErrorPattern)
 }

--- a/test/e2e/problemmaker/makers/filesystem_test.go
+++ b/test/e2e/problemmaker/makers/filesystem_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package makers
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Regexes are copied from the configs the e2e NPD loads (kernel-monitor.json,
+// readonly-monitor.json); the injected lines must keep matching them or the
+// e2e assertions in test/e2e/metriconly/metrics_test.go would fail on a real VM.
+func TestExt4FilesystemErrorMatchesMonitorRegexes(t *testing.T) {
+	lines := strings.Split(ext4ErrorPattern, "\n")
+	cases := []struct {
+		name  string
+		regex string
+	}{
+		{"Ext4Error counter", `EXT4-fs error .*`},
+		{"ReadonlyFilesystem gauge", `Remounting filesystem read-only`},
+	}
+	for _, tc := range cases {
+		re := regexp.MustCompile(tc.regex)
+		matched := false
+		for _, line := range lines {
+			if re.MatchString(line) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("no injected line matches %s regex %q; injected lines = %q", tc.name, tc.regex, lines)
+		}
+	}
+}


### PR DESCRIPTION
the ext4 e2e test got skipped in #970. `problem-maker` triggered a real ext4 error on the boot disk, and on kernel 6.5+ that shuts the whole filesystem down instead of just remounting it read-only. sshd dies and the test's ssh connection goes with it.

but NPD only reads /dev/kmsg, it never needed a real fault. now the maker just writes the two log lines a real error would print, the same as OOMKill and DockerHung. re-enables the test, drops the now-dead "stays healthy" check, and adds a unit test so the injected lines stay matched to the monitor regexes.

fixes #970

```release-note
NONE
```
