### PR TITLE
[release-1.35] chore(deps): bump build-image/debian-base to bookworm-v1.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . /src/
 WORKDIR /src
 RUN GOARCH=${TARGETARCH} make bin/node-problem-detector bin/health-checker bin/log-counter
 
-FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.7@sha256:368abceecc1308e0913a6fd5ab89a513ee4268becefc2a82dbe616462b29a46b AS base
+FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.8@sha256:bb933ac3606ff3f69854a7eba5da1eaef5064ef62d83f3cb0e4be40eb53522e0 AS base
 
 RUN clean-install util-linux bash libsystemd-dev
 


### PR DESCRIPTION
Cherry-pick of the debian-base bump from master (1d01ffae, dependabot).

Trivy / Docker Scout scans of the `release-1.35` post-submit image (`gcr.io/k8s-staging-npd/node-problem-detector:release-1.35`) flag fixable CRITICAL/HIGH CVEs that all come from the `bookworm-v1.0.7` base image:

- gnutls 3.7.9-2+deb12u5 → deb12u7: CVE-2026-33845, CVE-2026-42010 (CRITICAL), CVE-2026-33846, CVE-2026-42009, CVE-2026-3833, CVE-2026-42011, CVE-2026-42012, CVE-2026-5260 (HIGH)
- glibc 2.36-9+deb12u13 → deb12u14: CVE-2026-0861, CVE-2026-4046, CVE-2026-0915, CVE-2025-15281 (HIGH)
- libcap2 → deb12u3: CVE-2026-4878 (HIGH)

`bookworm-v1.0.8` (already used on master) contains all of these fixes; a scan of it shows no remaining fixable CRITICAL/HIGH findings.

```release-note
Update base image to debian-base:bookworm-v1.0.8 to fix CVEs in gnutls, glibc and libcap2
```