### PR TITLE
Fix invalid config JSON and enforce canonical config format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Build the node-problem-detector image.
 
 .PHONY: all \
-        lint vet fmt version test e2e-test \
+        lint vet fmt fmt-configs version test e2e-test \
         build-binaries build-container build-tar build \
         docker-builder build-in-docker \
         push-container push-tar push release clean depup \
@@ -143,6 +143,9 @@ vet:
 fmt: $(GOLANGCI_LINT)
 	find . -type f -name "*.go" | grep -v "./vendor/*" | xargs gofmt -s -w -l
 	$(GOLANGCI_LINT) run --config .golangci.yml --fix ./...
+
+fmt-configs:
+	UPDATE_EXPECTED=y go test -run TestShippedConfigs ./pkg/systemlogmonitor
 
 version:
 	@echo $(VERSION)

--- a/config/abrt-adaptor.json
+++ b/config/abrt-adaptor.json
@@ -1,38 +1,38 @@
 {
-	"plugin": "journald",
-	"pluginConfig": {
-		"source": "abrt-notification"
-	},
-	"logPath": "/var/log/journal",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "abrt-adaptor",
-	"conditions": [],
-	"rules": [
-		{
-			"type": "temporary",
-			"reason": "CCPPCrash",
-			"pattern": "Process \\d+ \\(\\S+\\) crashed in .*"
-		},
-		{
-			"type": "temporary",
-			"reason": "UncaughtException",
-			"pattern": "Process \\d+ \\(\\S+\\) of user \\d+ encountered an uncaught \\S+ exception"
-		},
-		{
-			"type": "temporary",
-			"reason": "XorgCrash",
-			"pattern": "Display server \\S+ crash in \\S+"
-		},
-		{
-			"type": "temporary",
-			"reason": "VMcore",
-			"pattern": "System encountered a fatal error in \\S+"
-		},
-		{
-			"type": "temporary",
-			"reason": "KernelOops",
-			"pattern": "System encountered a non-fatal error in \\S+"
-		}
-	]
+  "plugin": "journald",
+  "pluginConfig": {
+    "source": "abrt-notification"
+  },
+  "logPath": "/var/log/journal",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "abrt-adaptor",
+  "conditions": [],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "CCPPCrash",
+      "pattern": "Process \\d+ \\(\\S+\\) crashed in .*"
+    },
+    {
+      "type": "temporary",
+      "reason": "UncaughtException",
+      "pattern": "Process \\d+ \\(\\S+\\) of user \\d+ encountered an uncaught \\S+ exception"
+    },
+    {
+      "type": "temporary",
+      "reason": "XorgCrash",
+      "pattern": "Display server \\S+ crash in \\S+"
+    },
+    {
+      "type": "temporary",
+      "reason": "VMcore",
+      "pattern": "System encountered a fatal error in \\S+"
+    },
+    {
+      "type": "temporary",
+      "reason": "KernelOops",
+      "pattern": "System encountered a non-fatal error in \\S+"
+    }
+  ]
 }

--- a/config/disk-log-message-filelog.json
+++ b/config/disk-log-message-filelog.json
@@ -1,28 +1,31 @@
 {
-	"plugin": "filelog",
-	"pluginConfig": {
-		"timestamp": "^.{15}",
-		"message": "(?i)Currently unreadable.*sectors|(?i)Offline uncorrectable sectors",
-		"timestampFormat": "Jan _2 15:04:05"
-	},
-	"logPath": "/var/log/messages",
-	"lookback": "10h",
-	"bufferSize": 1,
-	"source": "disk-monitor",
-	"skipList": [ " audit:", " audit[" ],
-	"conditions": [
-		{
-			"type": "DiskBadBlock",
-			"reason": "DiskBadBlock",
-			"message": "Disk no bad block"
-		},
-	],
-	"rules": [
-		{
-			"type": "permanent",
-			"condition": "DiskBadBlock",
-			"reason": "DiskBadBlock",
-			"pattern": ".*([1-9]\\d{2,}) (Currently unreadable.*sectors|Offline uncorrectable sectors).*"
-		},
-	]
+  "plugin": "filelog",
+  "pluginConfig": {
+    "timestamp": "^.{15}",
+    "message": "(?i)Currently unreadable.*sectors|(?i)Offline uncorrectable sectors",
+    "timestampFormat": "Jan _2 15:04:05"
+  },
+  "logPath": "/var/log/messages",
+  "lookback": "10h",
+  "bufferSize": 1,
+  "source": "disk-monitor",
+  "skipList": [
+    " audit:",
+    " audit["
+  ],
+  "conditions": [
+    {
+      "type": "DiskBadBlock",
+      "reason": "DiskBadBlock",
+      "message": "Disk no bad block"
+    }
+  ],
+  "rules": [
+    {
+      "type": "permanent",
+      "condition": "DiskBadBlock",
+      "reason": "DiskBadBlock",
+      "pattern": ".*([1-9]\\d{2,}) (Currently unreadable.*sectors|Offline uncorrectable sectors).*"
+    }
+  ]
 }

--- a/config/docker-monitor-filelog.json
+++ b/config/docker-monitor-filelog.json
@@ -1,20 +1,20 @@
 {
-	"plugin": "filelog",
-	"pluginConfig": {
-		"timestamp": "^time=\"(\\S*)\"",
-		"message": "msg=\"([^\n]*)\"",
-		"timestampFormat": "2006-01-02T15:04:05.999999999-07:00"
-	},
-	"logPath": "/var/log/docker.log",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "docker-monitor",
-	"conditions": [],
-	"rules": [
-		{
-			"type": "temporary",
-			"reason": "CorruptDockerImage",
-			"pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
-		}
-	]
+  "plugin": "filelog",
+  "pluginConfig": {
+    "timestamp": "^time=\"(\\S*)\"",
+    "message": "msg=\"([^\n]*)\"",
+    "timestampFormat": "2006-01-02T15:04:05.999999999-07:00"
+  },
+  "logPath": "/var/log/docker.log",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "docker-monitor",
+  "conditions": [],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "CorruptDockerImage",
+      "pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
+    }
+  ]
 }

--- a/config/docker-monitor.json
+++ b/config/docker-monitor.json
@@ -1,36 +1,36 @@
 {
-	"plugin": "journald",
-	"pluginConfig": {
-		"source": "dockerd"
-	},
-	"logPath": "/var/log/journal",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "docker-monitor",
-	"metricsReporting": true,
-	"conditions": [
-		{
-			"type": "CorruptDockerOverlay2",
-			"reason": "NoCorruptDockerOverlay2",
-			"message": "docker overlay2 is functioning properly"
-		}
-	],
-	"rules": [
-		{
-			"type": "temporary",
-			"reason": "CorruptDockerImage",
-			"pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
-		},
-		{
-			"type": "permanent",
-			"condition": "CorruptDockerOverlay2",
-			"reason": "CorruptDockerOverlay2",
-			"pattern": "returned error: readlink /var/lib/docker/overlay2.*: invalid argument.*"
-		},
-		{
-			"type": "temporary",
-			"reason": "DockerContainerStartupFailure",
-			"pattern": "OCI runtime start failed: container process is already dead: unknown"
-		}
-	]
+  "plugin": "journald",
+  "pluginConfig": {
+    "source": "dockerd"
+  },
+  "logPath": "/var/log/journal",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "docker-monitor",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "CorruptDockerOverlay2",
+      "reason": "NoCorruptDockerOverlay2",
+      "message": "docker overlay2 is functioning properly"
+    }
+  ],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "CorruptDockerImage",
+      "pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
+    },
+    {
+      "type": "permanent",
+      "condition": "CorruptDockerOverlay2",
+      "reason": "CorruptDockerOverlay2",
+      "pattern": "returned error: readlink /var/lib/docker/overlay2.*: invalid argument.*"
+    },
+    {
+      "type": "temporary",
+      "reason": "DockerContainerStartupFailure",
+      "pattern": "OCI runtime start failed: container process is already dead: unknown"
+    }
+  ]
 }

--- a/config/exporter/stackdriver-exporter.json
+++ b/config/exporter/stackdriver-exporter.json
@@ -1,8 +1,8 @@
 {
-	"apiEndpoint": "monitoring.googleapis.com:443",
-	"exportPeriod": "60s",
-	"metadataFetchTimeout": "600s",
-	"metadataFetchInterval": "10s",
-	"panicOnMetadataFetchFailure": false,
-	"customMetricPrefix": ""
+  "apiEndpoint": "monitoring.googleapis.com:443",
+  "exportPeriod": "60s",
+  "metadataFetchTimeout": "600s",
+  "metadataFetchInterval": "10s",
+  "panicOnMetadataFetchFailure": false,
+  "customMetricPrefix": ""
 }

--- a/config/guestosconfig/known-modules.json
+++ b/config/guestosconfig/known-modules.json
@@ -1,69 +1,203 @@
 [
-  { "moduleName": "xt_MASQUERADE"},
-  { "moduleName": "xt_addrtype"},
-  { "moduleName": "iptable_nat"},
-  { "moduleName": "nf_nat"},
-  { "moduleName": "br_netfilter"},
-  { "moduleName": "ip6table_filter"},
-  { "moduleName": "ip6_tables"},
-  { "moduleName": "aesni_intel"},
-  { "moduleName": "glue_helper"},
-  { "moduleName": "crypto_simd"},
-  { "moduleName": "cryptd"},
-  { "moduleName": "virtio_balloon"},
-  { "moduleName": "loadpin_trigger"},
-  { "moduleName":"ip6table_filter"},
-  { "moduleName":"ip6_tables"},
-  { "moduleName":"iptable_filter"},
-  { "moduleName":"bpfilter"},
-  { "moduleName":"nls_iso8859_1"},
-  { "moduleName":"intel_rapl_msr"},
-  { "moduleName":"intel_rapl_common"},
-  { "moduleName":"sb_edac"},
-  { "moduleName":"rapl"},
-  { "moduleName":"input_leds"},
-  { "moduleName":"serio_raw"},
-  { "moduleName":"pvpanic"},
-  { "moduleName":"mac_hid"},
-  { "moduleName":"sch_fq_codel"},
-  { "moduleName":"ib_iser"},
-  { "moduleName":"rdma_cm"},
-  { "moduleName":"iw_cm"},
-  { "moduleName":"ib_cm"},
-  { "moduleName":"ib_core"},
-  { "moduleName":"iscsi_tcp"},
-  { "moduleName":"libiscsi_tcp"},
-  { "moduleName":"libiscsi"},
-  { "moduleName":"scsi_transport_iscsi"},
-  { "moduleName":"virtio_rng"},
-  { "moduleName":"ip_tables"},
-  { "moduleName":"x_tables"},
-  { "moduleName":"autofs4"},
-  { "moduleName":"btrfs"},
-  { "moduleName":"zstd_compress"},
-  { "moduleName":"raid10"},
-  { "moduleName":"raid456"},
-  { "moduleName":"async_raid6_recov"},
-  { "moduleName":"async_memcpy"},
-  { "moduleName":"async_pq"},
-  { "moduleName":"async_xor"},
-  { "moduleName":"async_tx"},
-  { "moduleName":"xor"},
-  { "moduleName":"raid6_pq"},
-  { "moduleName":"raid1"},
-  { "moduleName":"raid0"},
-  { "moduleName":"multipath"},
-  { "moduleName":"linear"},
-  { "moduleName":"crct10dif_pclmul"},
-  { "moduleName":"crc32_pclmul"},
-  { "moduleName":"ghash_clmulni_intel"},
-  { "moduleName":"aesni_intel"},
-  { "moduleName":"crypto_simd"},
-  { "moduleName":"cryptd"},
-  { "moduleName":"glue_helper"},
-  { "moduleName":"psmouse"},
-  { "moduleName":"virtio_net"},
-  { "moduleName":"net_failover"},
-  { "moduleName": "failover"},
-  { "moduleName":"i2c_piix4"}
+  {
+    "moduleName": "xt_MASQUERADE"
+  },
+  {
+    "moduleName": "xt_addrtype"
+  },
+  {
+    "moduleName": "iptable_nat"
+  },
+  {
+    "moduleName": "nf_nat"
+  },
+  {
+    "moduleName": "br_netfilter"
+  },
+  {
+    "moduleName": "ip6table_filter"
+  },
+  {
+    "moduleName": "ip6_tables"
+  },
+  {
+    "moduleName": "aesni_intel"
+  },
+  {
+    "moduleName": "glue_helper"
+  },
+  {
+    "moduleName": "crypto_simd"
+  },
+  {
+    "moduleName": "cryptd"
+  },
+  {
+    "moduleName": "virtio_balloon"
+  },
+  {
+    "moduleName": "loadpin_trigger"
+  },
+  {
+    "moduleName": "ip6table_filter"
+  },
+  {
+    "moduleName": "ip6_tables"
+  },
+  {
+    "moduleName": "iptable_filter"
+  },
+  {
+    "moduleName": "bpfilter"
+  },
+  {
+    "moduleName": "nls_iso8859_1"
+  },
+  {
+    "moduleName": "intel_rapl_msr"
+  },
+  {
+    "moduleName": "intel_rapl_common"
+  },
+  {
+    "moduleName": "sb_edac"
+  },
+  {
+    "moduleName": "rapl"
+  },
+  {
+    "moduleName": "input_leds"
+  },
+  {
+    "moduleName": "serio_raw"
+  },
+  {
+    "moduleName": "pvpanic"
+  },
+  {
+    "moduleName": "mac_hid"
+  },
+  {
+    "moduleName": "sch_fq_codel"
+  },
+  {
+    "moduleName": "ib_iser"
+  },
+  {
+    "moduleName": "rdma_cm"
+  },
+  {
+    "moduleName": "iw_cm"
+  },
+  {
+    "moduleName": "ib_cm"
+  },
+  {
+    "moduleName": "ib_core"
+  },
+  {
+    "moduleName": "iscsi_tcp"
+  },
+  {
+    "moduleName": "libiscsi_tcp"
+  },
+  {
+    "moduleName": "libiscsi"
+  },
+  {
+    "moduleName": "scsi_transport_iscsi"
+  },
+  {
+    "moduleName": "virtio_rng"
+  },
+  {
+    "moduleName": "ip_tables"
+  },
+  {
+    "moduleName": "x_tables"
+  },
+  {
+    "moduleName": "autofs4"
+  },
+  {
+    "moduleName": "btrfs"
+  },
+  {
+    "moduleName": "zstd_compress"
+  },
+  {
+    "moduleName": "raid10"
+  },
+  {
+    "moduleName": "raid456"
+  },
+  {
+    "moduleName": "async_raid6_recov"
+  },
+  {
+    "moduleName": "async_memcpy"
+  },
+  {
+    "moduleName": "async_pq"
+  },
+  {
+    "moduleName": "async_xor"
+  },
+  {
+    "moduleName": "async_tx"
+  },
+  {
+    "moduleName": "xor"
+  },
+  {
+    "moduleName": "raid6_pq"
+  },
+  {
+    "moduleName": "raid1"
+  },
+  {
+    "moduleName": "raid0"
+  },
+  {
+    "moduleName": "multipath"
+  },
+  {
+    "moduleName": "linear"
+  },
+  {
+    "moduleName": "crct10dif_pclmul"
+  },
+  {
+    "moduleName": "crc32_pclmul"
+  },
+  {
+    "moduleName": "ghash_clmulni_intel"
+  },
+  {
+    "moduleName": "aesni_intel"
+  },
+  {
+    "moduleName": "crypto_simd"
+  },
+  {
+    "moduleName": "cryptd"
+  },
+  {
+    "moduleName": "glue_helper"
+  },
+  {
+    "moduleName": "psmouse"
+  },
+  {
+    "moduleName": "virtio_net"
+  },
+  {
+    "moduleName": "net_failover"
+  },
+  {
+    "moduleName": "failover"
+  },
+  {
+    "moduleName": "i2c_piix4"
+  }
 ]

--- a/config/kernel-monitor-filelog.json
+++ b/config/kernel-monitor-filelog.json
@@ -1,52 +1,52 @@
 {
-	"plugin": "filelog",
-	"pluginConfig": {
-		"timestamp": "^.{15}",
-		"message": "kernel: \\[.*\\] (.*)",
-		"timestampFormat": "Jan _2 15:04:05"
-	},
-	"logPath": "/var/log/kern.log",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "kernel-monitor",
-	"conditions": [
-		{
-			"type": "KernelDeadlock",
-			"reason": "KernelHasNoDeadlock",
-			"message": "kernel has no deadlock"
-		}
-	],
-	"rules": [
-		{
-			"type": "temporary",
-			"reason": "OOMKilling",
-			"pattern": "Killed process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
-		},
-		{
-			"type": "temporary",
-			"reason": "TaskHung",
-			"pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
-		},
-		{
-			"type": "temporary",
-			"reason": "UnregisterNetDevice",
-			"pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
-		},
-		{
-			"type": "temporary",
-			"reason": "KernelOops",
-			"pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
-		},
-		{
-			"type": "temporary",
-			"reason": "KernelOops",
-			"pattern": "divide error: 0000 \\[#\\d+\\] SMP"
-		},
-		{
-			"type": "permanent",
-			"condition": "KernelDeadlock",
-			"reason": "DockerHung",
-			"pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
-		}
-	]
+  "plugin": "filelog",
+  "pluginConfig": {
+    "timestamp": "^.{15}",
+    "message": "kernel: \\[.*\\] (.*)",
+    "timestampFormat": "Jan _2 15:04:05"
+  },
+  "logPath": "/var/log/kern.log",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "kernel-monitor",
+  "conditions": [
+    {
+      "type": "KernelDeadlock",
+      "reason": "KernelHasNoDeadlock",
+      "message": "kernel has no deadlock"
+    }
+  ],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "OOMKilling",
+      "pattern": "Killed process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
+    },
+    {
+      "type": "temporary",
+      "reason": "TaskHung",
+      "pattern": "task \\S+:\\w+ blocked for more than \\w+ seconds\\."
+    },
+    {
+      "type": "temporary",
+      "reason": "UnregisterNetDevice",
+      "pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
+    },
+    {
+      "type": "temporary",
+      "reason": "KernelOops",
+      "pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
+    },
+    {
+      "type": "temporary",
+      "reason": "KernelOops",
+      "pattern": "divide error: 0000 \\[#\\d+\\] SMP"
+    },
+    {
+      "type": "permanent",
+      "condition": "KernelDeadlock",
+      "reason": "DockerHung",
+      "pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
+    }
+  ]
 }

--- a/config/kernel-monitor.json
+++ b/config/kernel-monitor.json
@@ -1,100 +1,100 @@
 {
-	"plugin": "kmsg",
-	"logPath": "/dev/kmsg",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "kernel-monitor",
-	"metricsReporting": true,
-	"conditions": [
-		{
-			"type": "KernelDeadlock",
-			"reason": "KernelHasNoDeadlock",
-			"message": "kernel has no deadlock"
-		},
-		{
-			"type": "XfsShutdown",
-			"reason": "XfsHasNotShutDown",
-			"message": "XFS has not shutdown"
-		},
-		{
-			"type": "CperHardwareErrorFatal",
-			"reason": "CperHardwareHasNoFatalError",
-			"message": "UEFI CPER has no fatal error"
-		}
-	],
-	"rules": [
-		{
-			"type": "temporary",
-			"reason": "OOMKilling",
-			"pattern": "Killed process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
-		},
-		{
-			"type": "temporary",
-			"reason": "TaskHung",
-			"pattern": "task [\\S ]+:\\w+ blocked for more than \\w+ seconds\\."
-		},
-		{
-			"type": "temporary",
-			"reason": "UnregisterNetDevice",
-			"pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
-		},
-		{
-			"type": "temporary",
-			"reason": "KernelOops",
-			"pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
-		},
-		{
-			"type": "temporary",
-			"reason": "KernelOops",
-			"pattern": "divide error: 0000 \\[#\\d+\\] SMP"
-		},
-		{
-			"type": "temporary",
-			"reason": "Ext4Error",
-			"pattern": "EXT4-fs error .*"
-		},
-		{
-			"type": "temporary",
-			"reason": "Ext4Warning",
-			"pattern": "EXT4-fs warning .*"
-		},
-		{
-			"type": "temporary",
-			"reason": "IOError",
-			"pattern": "Buffer I/O error .*"
-		},
-		{
-			"type": "permanent",
-			"condition": "XfsShutdown",
-			"reason": "XfsHasShutdown",
-			"pattern": "XFS .* Shutting down filesystem.?"
-		},
-		{
-			"type": "temporary",
-			"reason": "MemoryReadError",
-			"pattern": "CE memory read error .*"
-		},
-		{
-			"type": "temporary",
-			"reason": "CperHardwareErrorCorrected",
-			"pattern": ".*\\[Hardware Error\\]: event severity: corrected$"
-		},
-		{
-			"type": "temporary",
-			"reason": "CperHardwareErrorRecoverable",
-			"pattern": ".*\\[Hardware Error\\]: event severity: recoverable$"
-		},
-		{
-			"type": "permanent",
-			"condition": "CperHardwareErrorFatal",
-			"reason": "CperHardwareErrorFatal",
-			"pattern": ".*\\[Hardware Error\\]: event severity: fatal$"
-		},
-		{
-			"type": "permanent",
-			"condition": "KernelDeadlock",
-			"reason": "DockerHung",
-			"pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
-		}
-	]
+  "plugin": "kmsg",
+  "logPath": "/dev/kmsg",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "kernel-monitor",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "KernelDeadlock",
+      "reason": "KernelHasNoDeadlock",
+      "message": "kernel has no deadlock"
+    },
+    {
+      "type": "XfsShutdown",
+      "reason": "XfsHasNotShutDown",
+      "message": "XFS has not shutdown"
+    },
+    {
+      "type": "CperHardwareErrorFatal",
+      "reason": "CperHardwareHasNoFatalError",
+      "message": "UEFI CPER has no fatal error"
+    }
+  ],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "OOMKilling",
+      "pattern": "Killed process \\d+ (.+) total-vm:\\d+kB, anon-rss:\\d+kB, file-rss:\\d+kB.*"
+    },
+    {
+      "type": "temporary",
+      "reason": "TaskHung",
+      "pattern": "task [\\S ]+:\\w+ blocked for more than \\w+ seconds\\."
+    },
+    {
+      "type": "temporary",
+      "reason": "UnregisterNetDevice",
+      "pattern": "unregister_netdevice: waiting for \\w+ to become free. Usage count = \\d+"
+    },
+    {
+      "type": "temporary",
+      "reason": "KernelOops",
+      "pattern": "BUG: unable to handle kernel NULL pointer dereference at .*"
+    },
+    {
+      "type": "temporary",
+      "reason": "KernelOops",
+      "pattern": "divide error: 0000 \\[#\\d+\\] SMP"
+    },
+    {
+      "type": "temporary",
+      "reason": "Ext4Error",
+      "pattern": "EXT4-fs error .*"
+    },
+    {
+      "type": "temporary",
+      "reason": "Ext4Warning",
+      "pattern": "EXT4-fs warning .*"
+    },
+    {
+      "type": "temporary",
+      "reason": "IOError",
+      "pattern": "Buffer I/O error .*"
+    },
+    {
+      "type": "permanent",
+      "condition": "XfsShutdown",
+      "reason": "XfsHasShutdown",
+      "pattern": "XFS .* Shutting down filesystem.?"
+    },
+    {
+      "type": "temporary",
+      "reason": "MemoryReadError",
+      "pattern": "CE memory read error .*"
+    },
+    {
+      "type": "temporary",
+      "reason": "CperHardwareErrorCorrected",
+      "pattern": ".*\\[Hardware Error\\]: event severity: corrected$"
+    },
+    {
+      "type": "temporary",
+      "reason": "CperHardwareErrorRecoverable",
+      "pattern": ".*\\[Hardware Error\\]: event severity: recoverable$"
+    },
+    {
+      "type": "permanent",
+      "condition": "CperHardwareErrorFatal",
+      "reason": "CperHardwareErrorFatal",
+      "pattern": ".*\\[Hardware Error\\]: event severity: fatal$"
+    },
+    {
+      "type": "permanent",
+      "condition": "KernelDeadlock",
+      "reason": "DockerHung",
+      "pattern": "task docker:\\w+ blocked for more than \\w+ seconds\\."
+    }
+  ]
 }

--- a/config/readonly-monitor.json
+++ b/config/readonly-monitor.json
@@ -1,23 +1,23 @@
 {
-	"plugin": "kmsg",
-	"logPath": "/dev/kmsg",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "readonly-monitor",
-	"metricsReporting": true,
-	"conditions": [
-		{
-			"type": "ReadonlyFilesystem",
-			"reason": "FilesystemIsNotReadOnly",
-			"message": "Filesystem is not read-only"
-		}
-	],
-	"rules": [
-		{
-			"type": "permanent",
-			"condition": "ReadonlyFilesystem",
-			"reason": "FilesystemIsReadOnly",
-			"pattern": "Remounting filesystem read-only"
-		}
-	]
+  "plugin": "kmsg",
+  "logPath": "/dev/kmsg",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "readonly-monitor",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "ReadonlyFilesystem",
+      "reason": "FilesystemIsNotReadOnly",
+      "message": "Filesystem is not read-only"
+    }
+  ],
+  "rules": [
+    {
+      "type": "permanent",
+      "condition": "ReadonlyFilesystem",
+      "reason": "FilesystemIsReadOnly",
+      "pattern": "Remounting filesystem read-only"
+    }
+  ]
 }

--- a/config/systemd-monitor.json
+++ b/config/systemd-monitor.json
@@ -1,29 +1,29 @@
 {
-	"plugin": "journald",
-	"pluginConfig": {
-		"source": "systemd"
-	},
-	"logPath": "/var/log/journal",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "systemd-monitor",
-	"metricsReporting": true,
-	"conditions": [],
-	"rules": [
-		{
-			"type": "temporary",
-			"reason": "KubeletStart",
-			"pattern": "Started (Kubernetes kubelet|kubelet.service|kubelet.service - Kubernetes kubelet|kubelet.service - .*)."
-		},
-		{
-			"type": "temporary",
-			"reason": "DockerStart",
-			"pattern": "Starting (Docker Application Container Engine|docker.service|docker.service - Docker Application Container Engine)..."
-		},
-		{
-			"type": "temporary",
-			"reason": "ContainerdStart",
-			"pattern": "Starting (containerd container runtime|containerd.service|containerd.service - containerd container runtime)..."
-		}
-	]
+  "plugin": "journald",
+  "pluginConfig": {
+    "source": "systemd"
+  },
+  "logPath": "/var/log/journal",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "systemd-monitor",
+  "metricsReporting": true,
+  "conditions": [],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "KubeletStart",
+      "pattern": "Started (Kubernetes kubelet|kubelet.service|kubelet.service - Kubernetes kubelet|kubelet.service - .*)."
+    },
+    {
+      "type": "temporary",
+      "reason": "DockerStart",
+      "pattern": "Starting (Docker Application Container Engine|docker.service|docker.service - Docker Application Container Engine)..."
+    },
+    {
+      "type": "temporary",
+      "reason": "ContainerdStart",
+      "pattern": "Starting (containerd container runtime|containerd.service|containerd.service - containerd container runtime)..."
+    }
+  ]
 }

--- a/config/windows-containerd-monitor-filelog.json
+++ b/config/windows-containerd-monitor-filelog.json
@@ -1,30 +1,30 @@
 {
-	"plugin": "filelog",
-	"pluginConfig": {
-		"timestamp": "^time=\"(\\S*)\"",
-		"message": "msg=\"?([^\n]*)\"?",
-		"timestampFormat": "2006-01-02T15:04:05.999999999Z"
-	},
-	"logPath": "C:\\etc\\kubernetes\\logs\\containerd.log",
-	"lookback": "5m",
-	"bufferSize": 10,
-	"source": "containerd",
-	"conditions": [],
-	"rules": [
-		{
-			"type": "temporary",
-			"reason": "ContainerCreationFailed",
-			"pattern": ".*failed to create containerd container.*error unpacking image.*wrong diff id calculated on extraction.*"
-		},
-		{
-			"type": "temporary",
-			"reason": "CorruptContainerImageLayer",
-			"pattern": ".*failed to pull and unpack image.*failed to extract layer.*archive/tar: invalid tar header.*"
-		},
-		{
-			"type": "temporary",
-			"reason": "HCSEmptyLayerchain",
-			"pattern": ".*Failed to unmarshall layerchain json - invalid character '\\x00' looking for beginning of value*"
-		}
-	]
+  "plugin": "filelog",
+  "pluginConfig": {
+    "timestamp": "^time=\"(\\S*)\"",
+    "message": "msg=\"?([^\n]*)\"?",
+    "timestampFormat": "2006-01-02T15:04:05.999999999Z"
+  },
+  "logPath": "C:\\etc\\kubernetes\\logs\\containerd.log",
+  "lookback": "5m",
+  "bufferSize": 10,
+  "source": "containerd",
+  "conditions": [],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "ContainerCreationFailed",
+      "pattern": ".*failed to create containerd container.*error unpacking image.*wrong diff id calculated on extraction.*"
+    },
+    {
+      "type": "temporary",
+      "reason": "CorruptContainerImageLayer",
+      "pattern": ".*failed to pull and unpack image.*failed to extract layer.*archive/tar: invalid tar header.*"
+    },
+    {
+      "type": "temporary",
+      "reason": "HCSEmptyLayerchain",
+      "pattern": ".*Failed to unmarshall layerchain json - invalid character '\\x00' looking for beginning of value*"
+    }
+  ]
 }

--- a/config/windows-defender-monitor.json
+++ b/config/windows-defender-monitor.json
@@ -1,21 +1,20 @@
 {
-    "plugin": "custom",
-    "pluginConfig": {
-      "invoke_interval": "10m",
-      "timeout": "5s",
-      "max_output_length": 80,
-      "concurrency": 3
-    },
-    "source": "windows-defender-custom-plugin-monitor",
-    "metricsReporting": true,
-    "conditions": [],
-    "rules": [
-      {
-        "type": "temporary",
-        "reason": "WindowsDefenderThreatsDetected",
-        "path": "C:\\etc\\kubernetes\\node-problem-detector\\config\\plugin\\windows_defender_problem.ps1",
-        "timeout": "3s"
-      }
-    ]
-  }
-  
+  "plugin": "custom",
+  "pluginConfig": {
+    "invoke_interval": "10m",
+    "timeout": "5s",
+    "max_output_length": 80,
+    "concurrency": 3
+  },
+  "source": "windows-defender-custom-plugin-monitor",
+  "metricsReporting": true,
+  "conditions": [],
+  "rules": [
+    {
+      "type": "temporary",
+      "reason": "WindowsDefenderThreatsDetected",
+      "path": "C:\\etc\\kubernetes\\node-problem-detector\\config\\plugin\\windows_defender_problem.ps1",
+      "timeout": "3s"
+    }
+  ]
+}

--- a/config/windows-health-checker-containerd.json
+++ b/config/windows-health-checker-containerd.json
@@ -1,34 +1,34 @@
 {
-    "plugin": "custom",
-    "pluginConfig": {
-      "invoke_interval": "10s",
-      "timeout": "3m",
-      "max_output_length": 80,
-      "concurrency": 1
-    },
-    "source": "health-checker",
-    "metricsReporting": true,
-    "conditions": [
-      {
-        "type": "ContainerRuntimeUnhealthy",
-        "reason": "ContainerRuntimeIsHealthy",
-        "message": "Container runtime on the node is functioning properly"
-      }
-    ],
-    "rules": [
-      {
-        "type": "permanent",
-        "condition": "ContainerRuntimeUnhealthy",
-        "reason": "ContainerdUnhealthy",
-        "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
-        "args": [
-          "--component=cri",
-          "--enable-repair=true",
-          "--cooldown-time=2m",
-          "--cri-timeout=10s",
-          "--health-check-timeout=60s"
-        ],
-        "timeout": "3m"
-      }
-    ]
-  }
+  "plugin": "custom",
+  "pluginConfig": {
+    "invoke_interval": "10s",
+    "timeout": "3m",
+    "max_output_length": 80,
+    "concurrency": 1
+  },
+  "source": "health-checker",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "ContainerRuntimeUnhealthy",
+      "reason": "ContainerRuntimeIsHealthy",
+      "message": "Container runtime on the node is functioning properly"
+    }
+  ],
+  "rules": [
+    {
+      "type": "permanent",
+      "condition": "ContainerRuntimeUnhealthy",
+      "reason": "ContainerdUnhealthy",
+      "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
+      "args": [
+        "--component=cri",
+        "--enable-repair=true",
+        "--cooldown-time=2m",
+        "--cri-timeout=10s",
+        "--health-check-timeout=60s"
+      ],
+      "timeout": "3m"
+    }
+  ]
+}

--- a/config/windows-health-checker-docker.json
+++ b/config/windows-health-checker-docker.json
@@ -1,34 +1,33 @@
 {
-    "plugin": "custom",
-    "pluginConfig": {
-      "invoke_interval": "10s",
-      "timeout": "3m",
-      "max_output_length": 80,
-      "concurrency": 1
-    },
-    "source": "health-checker",
-    "metricsReporting": true,
-    "conditions": [
-      {
-        "type": "ContainerRuntimeUnhealthy",
-        "reason": "ContainerRuntimeIsHealthy",
-        "message": "Container runtime on the node is functioning properly"
-      }
-    ],
-    "rules": [
-      {
-        "type": "permanent",
-        "condition": "ContainerRuntimeUnhealthy",
-        "reason": "DockerUnhealthy",
-        "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
-        "args": [
-          "--component=docker",
-          "--enable-repair=true",
-          "--cooldown-time=2m",
-          "--health-check-timeout=60s"
-        ],
-        "timeout": "3m"
-      }
-    ]
-  }
-  
+  "plugin": "custom",
+  "pluginConfig": {
+    "invoke_interval": "10s",
+    "timeout": "3m",
+    "max_output_length": 80,
+    "concurrency": 1
+  },
+  "source": "health-checker",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "ContainerRuntimeUnhealthy",
+      "reason": "ContainerRuntimeIsHealthy",
+      "message": "Container runtime on the node is functioning properly"
+    }
+  ],
+  "rules": [
+    {
+      "type": "permanent",
+      "condition": "ContainerRuntimeUnhealthy",
+      "reason": "DockerUnhealthy",
+      "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
+      "args": [
+        "--component=docker",
+        "--enable-repair=true",
+        "--cooldown-time=2m",
+        "--health-check-timeout=60s"
+      ],
+      "timeout": "3m"
+    }
+  ]
+}

--- a/config/windows-health-checker-kubelet.json
+++ b/config/windows-health-checker-kubelet.json
@@ -1,34 +1,33 @@
 {
-    "plugin": "custom",
-    "pluginConfig": {
-      "invoke_interval": "10s",
-      "timeout": "3m",
-      "max_output_length": 80,
-      "concurrency": 1
-    },
-    "source": "health-checker",
-    "metricsReporting": true,
-    "conditions": [
-      {
-        "type": "KubeletUnhealthy",
-        "reason": "KubeletIsHealthy",
-        "message": "kubelet on the node is functioning properly"
-      }
-    ],
-    "rules": [
-      {
-        "type": "permanent",
-        "condition": "KubeletUnhealthy",
-        "reason": "KubeletUnhealthy",
-        "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
-        "args": [
-          "--component=kubelet",
-          "--enable-repair=true",
-          "--cooldown-time=1m",
-          "--health-check-timeout=10s"
-        ],
-        "timeout": "3m"
-      }
-    ]
-  }
-  
+  "plugin": "custom",
+  "pluginConfig": {
+    "invoke_interval": "10s",
+    "timeout": "3m",
+    "max_output_length": 80,
+    "concurrency": 1
+  },
+  "source": "health-checker",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "KubeletUnhealthy",
+      "reason": "KubeletIsHealthy",
+      "message": "kubelet on the node is functioning properly"
+    }
+  ],
+  "rules": [
+    {
+      "type": "permanent",
+      "condition": "KubeletUnhealthy",
+      "reason": "KubeletUnhealthy",
+      "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
+      "args": [
+        "--component=kubelet",
+        "--enable-repair=true",
+        "--cooldown-time=1m",
+        "--health-check-timeout=10s"
+      ],
+      "timeout": "3m"
+    }
+  ]
+}

--- a/config/windows-health-checker-kubeproxy.json
+++ b/config/windows-health-checker-kubeproxy.json
@@ -1,34 +1,33 @@
 {
-    "plugin": "custom",
-    "pluginConfig": {
-      "invoke_interval": "10s",
-      "timeout": "3m",
-      "max_output_length": 80,
-      "concurrency": 1
-    },
-    "source": "health-checker",
-    "metricsReporting": true,
-    "conditions": [
-      {
-        "type": "KubeProxyUnhealthy",
-        "reason": "KubeProxyIsHealthy",
-        "message": "kube-proxy on the node is functioning properly"
-      }
-    ],
-    "rules": [
-      {
-        "type": "permanent",
-        "condition": "KubeProxyUnhealthy",
-        "reason": "KubeProxyUnhealthy",
-        "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
-        "args": [
-          "--component=kube-proxy",
-          "--enable-repair=true",
-          "--cooldown-time=1m",
-          "--health-check-timeout=10s"
-        ],
-        "timeout": "3m"
-      }
-    ]
-  }
-  
+  "plugin": "custom",
+  "pluginConfig": {
+    "invoke_interval": "10s",
+    "timeout": "3m",
+    "max_output_length": 80,
+    "concurrency": 1
+  },
+  "source": "health-checker",
+  "metricsReporting": true,
+  "conditions": [
+    {
+      "type": "KubeProxyUnhealthy",
+      "reason": "KubeProxyIsHealthy",
+      "message": "kube-proxy on the node is functioning properly"
+    }
+  ],
+  "rules": [
+    {
+      "type": "permanent",
+      "condition": "KubeProxyUnhealthy",
+      "reason": "KubeProxyUnhealthy",
+      "path": "C:\\etc\\kubernetes\\node\\bin\\health-checker.exe",
+      "args": [
+        "--component=kube-proxy",
+        "--enable-repair=true",
+        "--cooldown-time=1m",
+        "--health-check-timeout=10s"
+      ],
+      "timeout": "3m"
+    }
+  ]
+}

--- a/pkg/systemlogmonitor/config_json_test.go
+++ b/pkg/systemlogmonitor/config_json_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package systemlogmonitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// canonicalJSON reformats src into the canonical format for shipped configs: 2-space indent and a
+// trailing newline. json.Indent only normalizes whitespace, so key order and values are preserved.
+func canonicalJSON(src []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, bytes.TrimSpace(src), "", "  "); err != nil {
+		return nil, err
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
+}
+
+// TestShippedConfigs verifies that every JSON file shipped in the config/ directory parses with
+// encoding/json, the same way the monitors load them at startup, and that it is written in the
+// canonical format. The parse check catches trailing commas, UTF-8 BOMs and other syntax errors
+// that would make NPD fail to start with the config. The format check keeps diffs in PRs minimal.
+// Run `make fmt-configs` to rewrite nonconforming files in the canonical format.
+func TestShippedConfigs(t *testing.T) {
+	configDir := filepath.Join("..", "..", "config")
+	// Match shipped configs at the top level and one directory down (e.g. config/exporter,
+	// config/guestosconfig); both are loaded via encoding/json and can crash NPD if malformed.
+	var configs []string
+	for _, pattern := range []string{"*.json", filepath.Join("*", "*.json")} {
+		matches, err := filepath.Glob(filepath.Join(configDir, pattern))
+		if err != nil {
+			t.Fatalf("failed to glob config files: %v", err)
+		}
+		configs = append(configs, matches...)
+	}
+	if len(configs) == 0 {
+		t.Fatal("no config files found in config/ directory")
+	}
+	for _, config := range configs {
+		t.Run(filepath.Base(config), func(t *testing.T) {
+			data, err := os.ReadFile(config)
+			if err != nil {
+				t.Fatalf("failed to read %q: %v", config, err)
+			}
+			var parsed interface{}
+			if err := json.Unmarshal(data, &parsed); err != nil {
+				t.Fatalf("failed to parse %q: %v", config, err)
+			}
+			canonical, err := canonicalJSON(data)
+			if err != nil {
+				t.Fatalf("failed to reformat %q: %v", config, err)
+			}
+			if bytes.Equal(data, canonical) {
+				return
+			}
+			if os.Getenv("UPDATE_EXPECTED") != "" {
+				if err := os.WriteFile(config, canonical, 0o644); err != nil {
+					t.Fatalf("failed to rewrite %q: %v", config, err)
+				}
+				t.Logf("rewrote %q in the canonical format", config)
+				return
+			}
+			assert.Equal(t, string(canonical), string(data),
+				"%q is not in the canonical format (2-space indent, trailing newline); "+
+					"run `make fmt-configs` to rewrite it",
+				config)
+		})
+	}
+}


### PR DESCRIPTION
`config/disk-log-message-filelog.json` contained trailing commas and no trailing newline, so it could not be parsed by `encoding/json` and NPD would fail to start when configured with it.

This PR:

- Fixes the invalid JSON.
- Adds `TestShippedConfigs`, which verifies that every shipped JSON config under `config/` — top level and one directory down (e.g. `config/exporter`, `config/guestosconfig`) — parses (catching trailing commas, UTF-8 BOMs and other syntax errors) and is in the canonical format (2-space indent, trailing newline), showing a diff on failure.
- Adds `make fmt-configs` to rewrite nonconforming files in place (`UPDATE_EXPECTED=y`).
- Normalizes the existing config files to the canonical format (whitespace-only changes).
